### PR TITLE
Update README to explain configuration approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
   - 本リポジトリでは **油圧**・**油温** を実装済み
 - 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
 - 回転数：50ms 間隔でサンプリング、シフトランプ設定可能  
-- 10Hz 更新のセンサログ出力（Serial または microSD）  
-- 自動輝度調整（オプション／GC0308 ALS対応）  
+- 10Hz 更新のセンサログ出力（Serial または microSD）
+- 自動輝度調整（オプション／GC0308 ALS対応）
+- 各種設定は `src/main.cpp` 冒頭の定数で変更可能
 
 ### ハードウェア構成
 | モジュール       | 型番 / 仕様                       | 備考                     |
@@ -59,8 +60,8 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 - Digital + bar graph temperature display  
 - RPM sampling every 50 ms, with configurable shift-light trigger  
 - 10 Hz data logging to Serial or SD  
-- Optional ambient light auto dimming (via GC0308 ALS)  
-- All parameters configurable in `config.h`  
+- Optional ambient light auto dimming (via GC0308 ALS)
+- Settings are defined at the top of `src/main.cpp`
 
 ### Hardware Configuration
 | Module           | Part / Spec                    | Notes                   |


### PR DESCRIPTION
## Summary
- document configurable constants in `src/main.cpp`
- drop outdated mention of `config.h`

## Testing
- `python3 -m platformio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_683fcf8336c483228834dba4036058e8