### PR TITLE
Add CI workflow for PlatformIO build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Build firmware
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Build
+        run: pio run -e m5stack-cores3


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the PlatformIO project

## Testing
- `pio --version`
- `pio run -e m5stack-cores3` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d8a0f05c48322974b48fc0112b029