### PR TITLE
Add CI workflow for PlatformIO build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: リポジトリをチェックアウト
+      - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Python をセットアップ
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: pip キャッシュを復元
+      - name: Restore pip cache
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/platformio.ini') }}
           restore-keys: ${{ runner.os }}-pip-
-      - name: PlatformIO キャッシュを復元
+      - name: Restore PlatformIO cache
         uses: actions/cache@v3
         with:
           path: |
@@ -29,7 +29,7 @@ jobs:
             ~/.platformio/packages
           key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini') }}
           restore-keys: ${{ runner.os }}-pio-
-      - name: PlatformIO をインストール
+      - name: Install PlatformIO
         run: pip install platformio
-      - name: ビルド
+      - name: Build
         run: pio run -e m5stack-cores3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Build firmware
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Build
+        run: pio run -e m5stack-cores3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: リポジトリをチェックアウト
         uses: actions/checkout@v3
-      - name: Set up Python
+      - name: Python をセットアップ
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install PlatformIO
+      - name: pip キャッシュを復元
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: PlatformIO キャッシュを復元
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.platformio/packages
+          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pio-
+      - name: PlatformIO をインストール
         run: pip install platformio
-      - name: Build
+      - name: ビルド
         run: pio run -e m5stack-cores3


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the PlatformIO project

## Testing
- `pio --version`
- `pio run -e m5stack-cores3` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d8a0f05c48322974b48fc0112b029