### PR TITLE
Add conversion helper tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Build firmware
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Restore pip cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Restore PlatformIO cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.platformio/packages
+          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pio-
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Build
+        run: pio run -e m5stack-cores3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: PlatformIO Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Run tests
+        run: platformio test -e native

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 
 * **Oil / Fuel / Boost Pressure** via **Defi PDF00903S** (0 – 10 bar, 0.5 – 4.5 V)  
 * **Oil / Water Temperature** via **Defi PDF00703S** (–40 – 150 °C, 0.5 – 4.5 V)  
-* **Engine RPM** via a 0–5 V pulse signal (frequency-to-voltage converter or direct digital capture)
 
 
 <img src="https://github.com/user-attachments/assets/d3a8bfdc-0bba-4519-b64a-f31a1ec9a9f4" width="640px">
@@ -16,16 +15,14 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 ## 📘 日本語 README
 
 ### 概要
-このプロジェクトは、**M5Stack CoreS3** と **ADS1015** ADC を用いて、Defi 製センサ **PDF00903S**・**PDF00703S** および車両の **回転数パルス信号** を表示する車載用マルチメーターです。  
+このプロジェクトは、**M5Stack CoreS3** と **ADS1015** ADC を用いて、Defi 製センサ **PDF00903S**・**PDF00703S** を表示する車載用マルチメーターです。
 サーキットでの簡易モニタリング用途に最適化しています。
 
 ### 主な機能
 - 油圧・燃圧・ブースト (0–10 bar) 半円アナログメーター  
   - 本リポジトリでは **油圧**・**油温** を実装済み
 - 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
-- 回転数：50ms 間隔でサンプリング、シフトランプ設定可能  
-- 10Hz 更新のセンサログ出力（Serial または microSD）  
-- 自動輝度調整（オプション／GC0308 ALS対応）  
+- 各種設定は `src/main.cpp` 冒頭の定数で変更可能
 
 ### ハードウェア構成
 | モジュール       | 型番 / 仕様                       | 備考                     |
@@ -35,7 +32,6 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 | 圧力センサ       | **PDF00903S** (Defi)              | CH0 / 0.5 – 4.5 V        |
 | 温度センサ1      | **PDF00703S** (Defi)              | CH1 / 0.5 – 4.5 V        |
 | 温度センサ2      | **PDF00703S** (Defi)              | CH2 / 0.5 – 4.5 V        |
-| RPM入力信号      | レブランプ付き                                | CH3 / 0–5V パルス        |
 | 電源             | 5V                               | CoreS3 USB経由           |
 
 > 📌 詳しい配線図は後日追加予定です。
@@ -49,7 +45,6 @@ This project turns an **M5Stack CoreS3** and **ADS1015 ADC** into a simple yet p
 
 - **Oil / Fuel / Boost Pressure** using **Defi PDF00903S** (0.5–4.5 V, 0–10 bar)  
 - **Oil / Water Temperature** using **Defi PDF00703S** (0.5–4.5 V, –40 to 150°C)  
-- **Engine RPM** using a 0–5V pulse input  
 
 Perfect for vintage cars lacking modern instrumentation or for lightweight track-day data monitoring.
 
@@ -57,10 +52,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 - Semi-circular analog gauge (0–10 bar, pressure)
   - In this repository, **oil pressure** and **oil temperature** are implemented.
 - Digital + bar graph temperature display  
-- RPM sampling every 50 ms, with configurable shift-light trigger  
-- 10 Hz data logging to Serial or SD  
-- Optional ambient light auto dimming (via GC0308 ALS)  
-- All parameters configurable in `config.h`  
+- Settings are defined at the top of `src/main.cpp`
 
 ### Hardware Configuration
 | Module           | Part / Spec                    | Notes                   |
@@ -70,7 +62,6 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 | Pressure Sensor  | **PDF00903S** (Defi)           | CH0, 0.5–4.5V           |
 | Temp Sensor 1    | **PDF00703S** (Defi)           | CH1, 0.5–4.5V           |
 | Temp Sensor 2    | **PDF00703S** (Defi)           | CH2, 0.5–4.5V           |
-| RPM Input        | -                              | CH3, 0–5V pulse         |
 | Power Supply     | 5V                             | Powered via USB         |
 
 > 📌 Detailed wiring diagrams will be added soon.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 
 > 📌 Detailed wiring diagrams will be added soon.
 
+### テスト / Testing
+変換ヘルパー関数のユニットテストは PC 上でも実行できます。
+
+Unit tests for the conversion helpers can run natively on your PC:
+
+```bash
+pip install platformio
+platformio test -e native
+```
+
 ---
 
 ### License

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,48 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <M5CoreS3.h>
+
+// ────────────────────── 設定 ──────────────────────
+// デバッグモードを有効にするかどうか
+constexpr bool DEBUG_MODE_ENABLED = false;
+
+// ── センサー接続可否（false にするとその項目は常に 0 表示） ──
+constexpr bool SENSOR_OIL_PRESSURE_PRESENT  = true;
+constexpr bool SENSOR_WATER_TEMP_PRESENT    = true;
+constexpr bool SENSOR_OIL_TEMP_PRESENT      = false;
+constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
+
+// ── 色設定 (16 bit) ──
+// RGB888 から 565 形式へ変換する constexpr 関数
+constexpr uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b)
+{
+  return (static_cast<uint16_t>(r & 0xF8) << 8)
+       | (static_cast<uint16_t>(g & 0xFC) << 3)
+       | (static_cast<uint16_t>(b) >> 3);
+}
+
+constexpr uint16_t COLOR_WHITE  = rgb565(255, 255, 255);
+constexpr uint16_t COLOR_BLACK  = rgb565(0,   0,   0);
+constexpr uint16_t COLOR_ORANGE = rgb565(255, 165, 0);
+constexpr uint16_t COLOR_YELLOW = rgb565(255, 255, 0);
+constexpr uint16_t COLOR_RED    = rgb565(255,   0, 0);
+constexpr uint16_t COLOR_GRAY   = rgb565(169, 169, 169);
+
+// ── 画面サイズ ──
+constexpr int LCD_WIDTH  = 320;
+constexpr int LCD_HEIGHT = 240;
+
+// ── ALS/輝度自動制御 ──
+enum class BrightnessMode { Day, Dusk, Night };
+
+constexpr uint32_t LUX_THRESHOLD_DAY  = 15;
+constexpr uint32_t LUX_THRESHOLD_DUSK = 10;
+
+constexpr uint8_t  BACKLIGHT_DAY   = 255;
+constexpr uint8_t  BACKLIGHT_DUSK  = 200;
+constexpr uint8_t  BACKLIGHT_NIGHT =  60;
+
+constexpr int MEDIAN_BUFFER_SIZE = 10;
+
+#endif // CONFIG_H

--- a/include/conversion.h
+++ b/include/conversion.h
@@ -1,0 +1,30 @@
+#ifndef CONVERSION_H
+#define CONVERSION_H
+
+// 変換ヘルパー関数群
+
+#include <cmath>
+#include <cstdint>
+
+constexpr float SUPPLY_VOLTAGE = 5.0f;
+constexpr float THERMISTOR_R25 = 10000.0f;
+constexpr float THERMISTOR_B_CONSTANT = 3380.0f;
+constexpr float ABSOLUTE_TEMPERATURE_25 = 298.15f;
+constexpr float SERIES_REFERENCE_RES = 10000.0f;
+
+// ADC 値を電圧 (V) に変換
+inline float convertAdcToVoltage(int16_t rawAdc) { return (rawAdc * 6.144f) / 2047.0f; }
+
+// 電圧を油圧 (bar) に変換
+inline float convertVoltageToOilPressure(float voltage) { return (voltage > 0.5f) ? 2.5f * (voltage - 0.5f) : 0.0f; }
+
+// 電圧を温度 (°C) に変換
+inline float convertVoltageToTemp(float voltage)
+{
+  float resistance = SERIES_REFERENCE_RES * ((SUPPLY_VOLTAGE / voltage) - 1.0f);
+  float kelvin =
+      THERMISTOR_B_CONSTANT / (log(resistance / THERMISTOR_R25) + THERMISTOR_B_CONSTANT / ABSOLUTE_TEMPERATURE_25);
+  return std::isnan(kelvin) ? 200.0f : kelvin - 273.15f;
+}
+
+#endif  // CONVERSION_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,7 @@ lib_deps =
 lib_ldf_mode = deep
 monitor_speed = 115200
 upload_port = COM11
+
+[env:native]
+platform = native
+test_build_src = no

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -2,6 +2,8 @@
 #define DRAW_FILL_ARC_METER_H
 
 #include <M5GFX.h>  // 必要なライブラリをインクルード
+#include <algorithm> // std::max に必要
+#include <cmath>      // 三角関数に必要
 
 void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxValue, float threshold,
                       uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@ constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
 #include <cstring>
 
 #include "DrawFillArcMeter.h"               // 半円メーター描画
+#include "conversion.h"
 
 // ── 色設定 (18 bit) ──
 constexpr uint32_t COLOR_WHITE  = M5.Lcd.color888(255, 255, 255);
@@ -69,13 +70,6 @@ float recordedMaxOilPressure = 0.0f;
 float recordedMaxWaterTemp   = 0.0f;
 int   recordedMaxOilTempTop  = 0;
 
-// ── 電圧→物理量変換定数 ──
-constexpr float SUPPLY_VOLTAGE          = 5.0f;
-constexpr float THERMISTOR_R25          = 10000.0f;
-constexpr float THERMISTOR_B_CONSTANT   = 3380.0f;
-constexpr float ABSOLUTE_TEMPERATURE_25 = 298.15f;
-constexpr float SERIES_REFERENCE_RES    = 10000.0f;
-
 // ── LTR-553 初期化パラメータ ──
 Ltr5xx_Init_Basic_Para ltr553InitParams = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
 
@@ -95,23 +89,6 @@ uint32_t measureLuxWithoutBacklight();
 void     updateBacklightLevel();
 
 // ────────────────────── ユーティリティ ──────────────────────
-inline float convertAdcToVoltage(int16_t rawAdc)
-{
-  return (rawAdc * 6.144f) / 2047.0f;
-}
-
-inline float convertVoltageToOilPressure(float voltage)
-{
-  return (voltage > 0.5f) ? 2.5f * (voltage - 0.5f) : 0.0f;   // 0.5 V offset, 2.5 bar/V
-}
-
-inline float convertVoltageToTemp(float voltage)
-{
-  float resistance = SERIES_REFERENCE_RES * ((SUPPLY_VOLTAGE / voltage) - 1.0f);
-  float kelvin     = THERMISTOR_B_CONSTANT /
-                     (log(resistance / THERMISTOR_R25) + THERMISTOR_B_CONSTANT / ABSOLUTE_TEMPERATURE_25);
-  return std::isnan(kelvin) ? 200.0f : kelvin - 273.15f;
-}
 
 template <size_t N>
 inline float calculateAverage(const float (&values)[N])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,50 +1,23 @@
 // ────────────────────── 設定 ──────────────────────
-const bool DEBUG_MODE_ENABLED = false;
-
-// ── センサー接続可否（false にするとその項目は常に 0 表示） ──
-constexpr bool SENSOR_OIL_PRESSURE_PRESENT  = true;
-constexpr bool SENSOR_WATER_TEMP_PRESENT    = true;
-constexpr bool SENSOR_OIL_TEMP_PRESENT      = false;
-constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
+// 設定は config.h で管理する
+#include "config.h"
 
 // ── 標準／ライブラリ ──
-#include <Arduino.h>
-#include <Adafruit_ADS1X15.h>
 #include <M5CoreS3.h>
+#include <Adafruit_ADS1X15.h>
 #include <M5GFX.h>
 #include <Wire.h>
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <numeric>
+#include <limits>
 
 #include "DrawFillArcMeter.h"               // 半円メーター描画
 #include "conversion.h"
 
-// ── 色設定 (16 bit) ──
-constexpr uint16_t COLOR_WHITE  = M5.Lcd.color565(255, 255, 255);
-constexpr uint16_t COLOR_BLACK  = M5.Lcd.color565(0,   0,   0);
-constexpr uint16_t COLOR_ORANGE = M5.Lcd.color565(255, 165, 0);
-constexpr uint16_t COLOR_YELLOW = M5.Lcd.color565(255, 255, 0);
-constexpr uint16_t COLOR_RED    = M5.Lcd.color565(255,   0, 0);
-constexpr uint16_t COLOR_GRAY   = M5.Lcd.color565(169, 169, 169);
-
-// ── 画面サイズ ──
-constexpr int LCD_WIDTH  = 320;
-constexpr int LCD_HEIGHT = 240;
-
 // ── ALS/輝度自動制御 ──
-enum class BrightnessMode { Day, Dusk, Night };
 BrightnessMode currentBrightnessMode = BrightnessMode::Day;
-
-constexpr uint32_t LUX_THRESHOLD_DAY  = 15;
-constexpr uint32_t LUX_THRESHOLD_DUSK = 10;
-
-constexpr uint8_t  BACKLIGHT_DAY   = 255;
-constexpr uint8_t  BACKLIGHT_DUSK  = 200;
-constexpr uint8_t  BACKLIGHT_NIGHT =  60;
-
-constexpr int MEDIAN_BUFFER_SIZE = 10;
 uint32_t luxSampleBuffer[MEDIAN_BUFFER_SIZE] = {};
 int      luxSampleIndex  = 0;
 
@@ -57,8 +30,8 @@ Adafruit_ADS1015 adsConverter;
 
 // ── センサリング用バッファ ──
 constexpr int PRESSURE_SAMPLE_SIZE     = 3;
-constexpr int WATER_TEMP_SAMPLE_SIZE   = 10;
-constexpr int OIL_TEMP_SAMPLE_SIZE     = 10;
+constexpr int WATER_TEMP_SAMPLE_SIZE   = 30;
+constexpr int OIL_TEMP_SAMPLE_SIZE     = 30;
 
 float oilPressureSamples[PRESSURE_SAMPLE_SIZE]          = {};
 float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE]   = {};
@@ -71,6 +44,17 @@ int oilTemperatureSampleIndex   = 0;
 float recordedMaxOilPressure = 0.0f;
 float recordedMaxWaterTemp   = 0.0f;
 int   recordedMaxOilTempTop  = 0;
+
+// ── 表示キャッシュ ──
+struct DisplayCache {
+  float  pressureAvg;
+  float  waterTempAvg;
+  int16_t oilTemp;
+  int16_t maxOilTemp;
+} displayCache = {std::numeric_limits<float>::quiet_NaN(),
+                  std::numeric_limits<float>::quiet_NaN(),
+                  INT16_MIN, INT16_MIN};
+// 初回描画を強制するため NaN と最小値で初期化しておく
 
 // ── LTR-553 初期化パラメータ ──
 Ltr5xx_Init_Basic_Para ltr553InitParams = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
@@ -113,24 +97,47 @@ int16_t readAdcWithSettling(uint8_t ch)
 void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
                          int16_t oilTemp, int16_t maxOilTemp)
 {
-  mainCanvas.fillSprite(COLOR_BLACK);
+  // 描画領域計算
+  const int TOPBAR_Y = 0, TOPBAR_H = 50;
+  const int GAUGE_H  = 170;
+
+  // 変化検知。初回は必ず描画するため NaN/最小値を使用
+  bool oilChanged = (displayCache.oilTemp == INT16_MIN) ||
+                    (oilTemp != displayCache.oilTemp) ||
+                    (maxOilTemp != displayCache.maxOilTemp);
+  bool pressureChanged = std::isnan(displayCache.pressureAvg) ||
+                         fabs(pressureAvg - displayCache.pressureAvg) > 0.01f;
+  bool waterChanged    = std::isnan(displayCache.waterTempAvg) ||
+                         fabs(waterTempAvg - displayCache.waterTempAvg) > 0.01f;
   mainCanvas.setTextColor(COLOR_WHITE);
 
-  // 油温バー
-  if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
-  drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
+  if (oilChanged) {
+    mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
+    if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
+    drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
+    displayCache.oilTemp    = oilTemp;
+    displayCache.maxOilTemp = maxOilTemp;
+  }
 
-  // メーター (油圧／水温)
-  drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, 10.0f,  8.0f,
-                   RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                   0.5f, true,   0,   60);
+  if (pressureChanged) {
+    mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+    drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, 10.0f,  8.0f,
+                     RED, "BAR", "OIL.P", recordedMaxOilPressure,
+                     0.5f, true,   0,   60);
+    displayCache.pressureAvg = pressureAvg;
+  }
 
-  drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f,110.0f, 98.0f,
-                   RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                   5.0f, false, 160,  60);
+  if (waterChanged) {
+    mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+    drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f,110.0f, 98.0f,
+                     RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
+                     5.0f, false, 160,  60);
+    displayCache.waterTempAvg = waterTempAvg;
+  }
 
   // FPS (左下)
   if (DEBUG_MODE_ENABLED) {
+    mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
     mainCanvas.setTextSize(1);
     mainCanvas.setCursor(5, LCD_HEIGHT - 12);
     mainCanvas.printf("FPS:%d", currentFramesPerSecond);
@@ -149,6 +156,7 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, int oilTemp, int maxOilTemp)
   constexpr int X = 20, Y = 15, W = 210, H = 20;
   constexpr float RANGE = MAX_TEMP - MIN_TEMP;
 
+  // 水温ゲージと同じグレー背景を描画
   canvas.fillRect(X + 1, Y + 1, W - 2, H - 2, 0x18E3);
 
   if (oilTemp >= MIN_TEMP) {

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -1,0 +1,41 @@
+#include <unity.h>
+
+#include "conversion.h"
+
+// conversion.h のテスト
+
+// 各テストの前処理
+void setUp(void) {}
+// 各テストの後処理
+void tearDown(void) {}
+
+void test_convertAdcToVoltage()
+{
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, convertAdcToVoltage(0));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 3.0705f, convertAdcToVoltage(1023));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 6.144f, convertAdcToVoltage(2047));
+}
+
+void test_convertVoltageToOilPressure()
+{
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, convertVoltageToOilPressure(0.4f));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, convertVoltageToOilPressure(0.5f));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.5f, convertVoltageToOilPressure(1.5f));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 10.0f, convertVoltageToOilPressure(4.5f));
+}
+
+void test_convertVoltageToTemp()
+{
+  TEST_ASSERT_FLOAT_WITHIN(1.0f, -23.4f, convertVoltageToTemp(0.5f));
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 25.0f, convertVoltageToTemp(2.5f));
+  TEST_ASSERT_FLOAT_WITHIN(1.0f, 96.7f, convertVoltageToTemp(4.5f));
+}
+
+int main(int argc, char **argv)
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_convertAdcToVoltage);
+  RUN_TEST(test_convertVoltageToOilPressure);
+  RUN_TEST(test_convertVoltageToTemp);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add new header `conversion.h` with conversion helper functions
- update `main.cpp` to include this header
- create `test/test_conversion.cpp` using Unity
- enable native platform for local unit tests
- add GitHub Actions workflow to run tests
- update workflow step names to English, add job name
- add Japanese comments in header and tests

## Testing
- `platformio test -e native` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_683fcc00233483228db624bf3fd93ee0