### PR TITLE
Add clang tools to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,13 @@ jobs:
           restore-keys: ${{ runner.os }}-pio-
       - name: Install PlatformIO
         run: pip install platformio
+      - name: Install clang tools
+        run: sudo apt-get update && sudo apt-get install -y clang-format clang-tidy
+      - name: Run clang-format
+        run: |
+          clang-format -n --Werror $(find src include -name '*.cpp' -o -name '*.h')
+      - name: Run clang-tidy
+        run: |
+          clang-tidy $(find src -name '*.cpp') -- -Iinclude -std=c++17
       - name: Build
         run: pio run -e m5stack-cores3


### PR DESCRIPTION
## Summary
- run clang-format and clang-tidy in CI

## Testing
- `clang-format -n --Werror $(find src include -name '*.cpp' -o -name '*.h')`
- `clang-tidy src/main.cpp -- -Iinclude -std=c++17`



------
https://chatgpt.com/codex/tasks/task_e_684d97c6d8a083228a66b3bd32f6fa31