### PR TITLE
Add clang checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,19 @@ jobs:
           restore-keys: ${{ runner.os }}-pio-
       - name: Install PlatformIO
         run: pip install platformio
+      - name: Install clang tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format clang-tidy
+      - name: Generate compilation database
+        run: |
+          pio run -e m5stack-cores3 -t compiledb
+          cp .pio/build/m5stack-cores3/compile_commands.json compile_commands.json
+      - name: clang-format でコード整形をチェック
+        run: |
+          git ls-files src/*.cpp src/*.h | xargs clang-format --dry-run --Werror
+      - name: clang-tidy で静的解析を実行
+        run: |
+          git ls-files src/*.cpp | xargs clang-tidy --warnings-as-errors=* -p .
       - name: Build
         run: pio run -e m5stack-cores3


### PR DESCRIPTION
## Summary / サマリー
- add clang-format/clang-tidy steps

## Testing
- `pio run -e m5stack-cores3` *(fails: HTTPClientError)*
- `clang-format --dry-run --Werror` *(fails: code not formatted)*
- `clang-tidy --warnings-as-errors=*` *(fails: compilation database not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8bd9d32c8322a4eb68dc7d7579de