### PR TITLE
メーター描画の最適化 / Optimize gauge drawing

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -2,26 +2,27 @@
 #define DRAW_FILL_ARC_METER_H
 
 #include <M5GFX.h>  // 必要なライブラリをインクルード
+
 #include <algorithm>
 #include <cmath>
 
+// drawTicks が true の場合は目盛りとラベルも描画する
 void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxValue, float threshold,
                       uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,
-                      float tickStep,  // 目盛の間隔
+                      float tickStep,   // 目盛の間隔
                       bool useDecimal,  // 小数点を表示するかどうか
-                      int x, int y
-)
+                      int x, int y, bool drawTicks = true)
 {
   const int CENTER_X_CORRECTED = x + 75 + 5;   // スプライト内の中心X座標
   const int CENTER_Y_CORRECTED = y + 90 - 10;  // スプライト内の中心Y座標
-  const int RADIUS = 70;                   // 半円メーターの半径
-  const int ARC_WIDTH = 10;                // 弧の幅
+  const int RADIUS = 70;                       // 半円メーターの半径
+  const int ARC_WIDTH = 10;                    // 弧の幅
 
-  const uint16_t BACKGROUND_COLOR = BLACK;                // 背景色
-  const uint16_t ACTIVE_COLOR = WHITE;                    // 現在の値の色
-  const uint16_t INACTIVE_COLOR = 0x18E3;                 // メーター全体の背景色
-  const uint16_t TEXT_COLOR = WHITE;                      // テキストの色
-  const uint16_t MAX_VALUE_COLOR = RED;                   // 最大値の印の色
+  const uint16_t BACKGROUND_COLOR = BLACK;  // 背景色
+  const uint16_t ACTIVE_COLOR = WHITE;      // 現在の値の色
+  const uint16_t INACTIVE_COLOR = 0x18E3;   // メーター全体の背景色
+  const uint16_t TEXT_COLOR = WHITE;        // テキストの色
+  const uint16_t MAX_VALUE_COLOR = RED;     // 最大値の印の色
 
   // 最大値を更新
   maxRecordedValue = std::max(value, maxRecordedValue);
@@ -73,35 +74,38 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
     );
   }
 
-  // 目盛ラベルと目盛り線を描画
-  int tickCount = static_cast<int>((maxValue - minValue) / tickStep) + 1;
-  for (float i = 0; i <= tickCount - 1; i += 1)
+  if (drawTicks)
   {
-    float scaledValue = minValue + (tickStep * i);
-    float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
-    float rad = radians(angle);
-
-    int lineX1 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 10));
-    int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 10));
-    int lineX2 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 5));
-    int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 5));
-
-    canvas.drawLine(lineX1, lineY1, lineX2, lineY2, WHITE);
-
-    // 整数値の目盛ラベルを描画
-    if (fmod(scaledValue, 1.0) == 0)
+    // 目盛ラベルと目盛り線を描画
+    int tickCount = static_cast<int>((maxValue - minValue) / tickStep) + 1;
+    for (float i = 0; i <= tickCount - 1; i += 1)
     {
-      int labelX = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 15));
-      int labelY = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 15));
+      float scaledValue = minValue + (tickStep * i);
+      float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
+      float rad = radians(angle);
 
-      char labelText[6];
-      snprintf(labelText, sizeof(labelText), "%.0f", scaledValue);
+      int lineX1 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 10));
+      int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 10));
+      int lineX2 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 5));
+      int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 5));
 
-      canvas.setTextFont(1);
-      canvas.setFont(&fonts::Font0);
-      canvas.setTextColor(TEXT_COLOR, BACKGROUND_COLOR);
-      canvas.setCursor(labelX - (canvas.textWidth(labelText) / 2), labelY - 4);
-      canvas.print(labelText);
+      canvas.drawLine(lineX1, lineY1, lineX2, lineY2, WHITE);
+
+      // 整数値の目盛ラベルを描画
+      if (fmod(scaledValue, 1.0) == 0)
+      {
+        int labelX = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 15));
+        int labelY = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 15));
+
+        char labelText[6];
+        snprintf(labelText, sizeof(labelText), "%.0f", scaledValue);
+
+        canvas.setTextFont(1);
+        canvas.setFont(&fonts::Font0);
+        canvas.setTextColor(TEXT_COLOR, BACKGROUND_COLOR);
+        canvas.setCursor(labelX - (canvas.textWidth(labelText) / 2), labelY - 4);
+        canvas.print(labelText);
+      }
     }
   }
 
@@ -122,14 +126,17 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   canvas.setCursor(valueX - canvas.textWidth(valueText), valueY - (canvas.fontHeight() / 2));
   canvas.print(valueText);
 
-  // 単位とメーター名を表示
-  char combinedLabel[30];
-  snprintf(combinedLabel, sizeof(combinedLabel), "%s / %s", label, unit);
-  canvas.setFont(&fonts::Font0);
-  int labelX = CENTER_X_CORRECTED;
-  int labelY = CENTER_Y_CORRECTED + RADIUS + 15;
-  canvas.setCursor(labelX - (canvas.textWidth(combinedLabel) / 2), labelY);
-  canvas.print(combinedLabel);
+  if (drawTicks)
+  {
+    // 単位とメーター名を表示
+    char combinedLabel[30];
+    snprintf(combinedLabel, sizeof(combinedLabel), "%s / %s", label, unit);
+    canvas.setFont(&fonts::Font0);
+    int labelX = CENTER_X_CORRECTED;
+    int labelY = CENTER_Y_CORRECTED + RADIUS + 15;
+    canvas.setCursor(labelX - (canvas.textWidth(combinedLabel) / 2), labelY);
+    canvas.print(combinedLabel);
+  }
 }
 
-#endif // DRAW_FILL_ARC_METER_H
+#endif  // DRAW_FILL_ARC_METER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,92 +3,88 @@
 #include "config.h"
 
 // ── 標準／ライブラリ ──
-#include <M5CoreS3.h>
 #include <Adafruit_ADS1X15.h>
+#include <M5CoreS3.h>
 #include <M5GFX.h>
 #include <Wire.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <numeric>
 #include <limits>
+#include <numeric>
 
-#include "DrawFillArcMeter.h"               // 半円メーター描画
+#include "DrawFillArcMeter.h"  // 半円メーター描画
 
 // ── ALS/輝度自動制御 ──
 BrightnessMode currentBrightnessMode = BrightnessMode::Day;
 uint32_t luxSampleBuffer[MEDIAN_BUFFER_SIZE] = {};
-int      luxSampleIndex  = 0;
+int luxSampleIndex = 0;
 
 // ── M5 & GFX ──
-M5GFX    display;
+M5GFX display;
 M5Canvas mainCanvas(&display);
 
 // ── ADS1015 ──
 Adafruit_ADS1015 adsConverter;
 
 // ── センサリング用バッファ ──
-constexpr int PRESSURE_SAMPLE_SIZE     = 3;
-constexpr int WATER_TEMP_SAMPLE_SIZE   = 30;
-constexpr int OIL_TEMP_SAMPLE_SIZE     = 30;
+constexpr int PRESSURE_SAMPLE_SIZE = 3;
+constexpr int WATER_TEMP_SAMPLE_SIZE = 30;
+constexpr int OIL_TEMP_SAMPLE_SIZE = 30;
 
-float oilPressureSamples[PRESSURE_SAMPLE_SIZE]          = {};
-float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE]   = {};
-float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE]       = {};
+float oilPressureSamples[PRESSURE_SAMPLE_SIZE] = {};
+float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE] = {};
+float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE] = {};
 
-int oilPressureSampleIndex      = 0;
+int oilPressureSampleIndex = 0;
 int waterTemperatureSampleIndex = 0;
-int oilTemperatureSampleIndex   = 0;
+int oilTemperatureSampleIndex = 0;
 
 float recordedMaxOilPressure = 0.0f;
-float recordedMaxWaterTemp   = 0.0f;
-int   recordedMaxOilTempTop  = 0;
+float recordedMaxWaterTemp = 0.0f;
+int recordedMaxOilTempTop = 0;
 
 // ── 表示キャッシュ ──
-struct DisplayCache {
-  float  pressureAvg;
-  float  waterTempAvg;
+struct DisplayCache
+{
+  float pressureAvg;
+  float waterTempAvg;
   int16_t oilTemp;
   int16_t maxOilTemp;
-} displayCache = {std::numeric_limits<float>::quiet_NaN(),
-                  std::numeric_limits<float>::quiet_NaN(),
-                  INT16_MIN, INT16_MIN};
+} displayCache = {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(), INT16_MIN, INT16_MIN};
 // 初回描画を強制するため NaN と最小値で初期化しておく
 
 // ── 電圧→物理量変換定数 ──
-constexpr float SUPPLY_VOLTAGE          = 5.0f;
-constexpr float THERMISTOR_R25          = 10000.0f;
-constexpr float THERMISTOR_B_CONSTANT   = 3380.0f;
-constexpr float ABSOLUTE_TEMPERATURE_25 = 298.16f;       // 273.16 + 25
-constexpr float SERIES_REFERENCE_RES    = 10000.0f;
+constexpr float SUPPLY_VOLTAGE = 5.0f;
+constexpr float THERMISTOR_R25 = 10000.0f;
+constexpr float THERMISTOR_B_CONSTANT = 3380.0f;
+constexpr float ABSOLUTE_TEMPERATURE_25 = 298.16f;  // 273.16 + 25
+constexpr float SERIES_REFERENCE_RES = 10000.0f;
 
 // ── LTR-553 初期化パラメータ ──
 Ltr5xx_Init_Basic_Para ltr553InitParams = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
 
 // ── FPS 計測 ──
-unsigned long previousFpsTimestamp   = 0;
-int           frameCounterPerSecond  = 0;
-int           currentFramesPerSecond = 0;
+unsigned long previousFpsTimestamp = 0;
+int frameCounterPerSecond = 0;
+int currentFramesPerSecond = 0;
 
 // ────────────────────── プロトタイプ ──────────────────────
 void drawOilTemperatureTopBar(M5Canvas& canvas, int oilTemp, int maxOilTemp);
-void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
-                         int16_t oilTemp, int16_t maxOilTemp);
+void renderDisplayAndLog(float pressureAvg, float waterTempAvg, int16_t oilTemp, int16_t maxOilTemp);
 void updateGauges();
 void acquireSensorData();
 
 uint32_t measureLuxWithoutBacklight();
-void     updateBacklightLevel();
+void updateBacklightLevel();
 
 // ────────────────────── ユーティリティ ──────────────────────
-inline float convertAdcToVoltage(int16_t rawAdc)
-{
-  return (rawAdc * 6.144f) / 2047.0f;
-}
+inline float convertAdcToVoltage(int16_t rawAdc) { return (rawAdc * 6.144f) / 2047.0f; }
 
 inline float convertVoltageToOilPressure(float voltage)
 {
-  return (voltage > 0.5f) ? 2.5f * (voltage - 0.5f) : 0.0f;   // 0.5 V offset, 2.5 bar/V
+  return (voltage > 0.5f) ? 2.5f * (voltage - 0.5f) : 0.0f;  // 0.5 V offset, 2.5 bar/V
 }
 
 inline float convertVoltageToTemp(float voltage)
@@ -96,9 +92,9 @@ inline float convertVoltageToTemp(float voltage)
   // センサー電圧が 0 の場合はゼロ除算を避けるため早期リターン
   if (voltage <= 0.0f) return 200.0f;
   float resistance = SERIES_REFERENCE_RES * ((SUPPLY_VOLTAGE / voltage) - 1.0f);
-  float kelvin     = THERMISTOR_B_CONSTANT /
-                     (log(resistance / THERMISTOR_R25) + THERMISTOR_B_CONSTANT / ABSOLUTE_TEMPERATURE_25);
-  return std::isnan(kelvin) ? 200.0f : kelvin - 273.16f;   // Kelvin→℃ 変換
+  float kelvin =
+      THERMISTOR_B_CONSTANT / (log(resistance / THERMISTOR_R25) + THERMISTOR_B_CONSTANT / ABSOLUTE_TEMPERATURE_25);
+  return std::isnan(kelvin) ? 200.0f : kelvin - 273.16f;  // Kelvin→℃ 変換
 }
 
 template <size_t N>
@@ -109,60 +105,78 @@ inline float calculateAverage(const float (&values)[N])
 }
 
 // ────────────────────── ★ ADC セトリング付き読み取り ──────────────────────
-constexpr uint32_t ADC_SETTLING_US = 50;             // 残留電荷クリア待ち
+constexpr uint32_t ADC_SETTLING_US = 50;  // 残留電荷クリア待ち
 int16_t readAdcWithSettling(uint8_t ch)
 {
-  adsConverter.readADC_SingleEnded(ch);              // ダミー変換
-  delayMicroseconds(ADC_SETTLING_US);                // セトリング待ち
-  return adsConverter.readADC_SingleEnded(ch);       // 本変換
+  adsConverter.readADC_SingleEnded(ch);         // ダミー変換
+  delayMicroseconds(ADC_SETTLING_US);           // セトリング待ち
+  return adsConverter.readADC_SingleEnded(ch);  // 本変換
 }
 
-
 // ────────────────────── 画面更新＋ログ ──────────────────────
-void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
-                         int16_t oilTemp, int16_t maxOilTemp)
+void renderDisplayAndLog(float pressureAvg, float waterTempAvg, int16_t oilTemp, int16_t maxOilTemp)
 {
   // 描画領域計算
   const int TOPBAR_Y = 0, TOPBAR_H = 50;
-  const int GAUGE_H  = 170;
+  const int GAUGE_H = 170;
 
   // 変化検知。初回は必ず描画するため NaN/最小値を使用
-  bool oilChanged = (displayCache.oilTemp == INT16_MIN) ||
-                    (oilTemp != displayCache.oilTemp) ||
-                    (maxOilTemp != displayCache.maxOilTemp);
-  bool pressureChanged = std::isnan(displayCache.pressureAvg) ||
-                         fabs(pressureAvg - displayCache.pressureAvg) > 0.01f;
-  bool waterChanged    = std::isnan(displayCache.waterTempAvg) ||
-                         fabs(waterTempAvg - displayCache.waterTempAvg) > 0.01f;
+  bool oilChanged =
+      (displayCache.oilTemp == INT16_MIN) || (oilTemp != displayCache.oilTemp) || (maxOilTemp != displayCache.maxOilTemp);
+  bool pressureChanged = std::isnan(displayCache.pressureAvg) || fabs(pressureAvg - displayCache.pressureAvg) > 0.01f;
+  bool waterChanged = std::isnan(displayCache.waterTempAvg) || fabs(waterTempAvg - displayCache.waterTempAvg) > 0.01f;
 
   mainCanvas.setTextColor(COLOR_WHITE);
 
-  if (oilChanged) {
+  if (oilChanged)
+  {
     mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
     if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
     drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
-    displayCache.oilTemp    = oilTemp;
+    displayCache.oilTemp = oilTemp;
     displayCache.maxOilTemp = maxOilTemp;
   }
 
-  if (pressureChanged) {
-    mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
-    drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, 10.0f,  8.0f,
-                     RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                     0.5f, true,   0,   60);
+  static bool pressureGaugeDrawn = false;
+  static bool waterGaugeDrawn = false;
+
+  if (pressureChanged)
+  {
+    if (!pressureGaugeDrawn)
+    {
+      mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+      drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, 10.0f, 8.0f, RED, "BAR", "OIL.P", recordedMaxOilPressure, 0.5f, true,
+                       0, 60, true);
+      pressureGaugeDrawn = true;
+    }
+    else
+    {
+      drawFillArcMeter(mainCanvas, pressureAvg, 0.0f, 10.0f, 8.0f, RED, "BAR", "OIL.P", recordedMaxOilPressure, 0.5f, true,
+                       0, 60, false);
+    }
     displayCache.pressureAvg = pressureAvg;
   }
 
-  if (waterChanged) {
-    mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
-    drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f,110.0f, 98.0f,
-                     RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                     5.0f, false, 160,  60);
+  if (waterChanged)
+  {
+    if (!waterGaugeDrawn)
+    {
+      mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+      drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f, 110.0f, 98.0f, RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
+                       5.0f, false, 160, 60, true);
+      waterGaugeDrawn = true;
+    }
+    else
+    {
+      drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f, 110.0f, 98.0f, RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
+                       5.0f, false, 160, 60, false);
+    }
     displayCache.waterTempAvg = waterTempAvg;
   }
 
   // FPS (左下)
-  if (DEBUG_MODE_ENABLED) {
+  if (DEBUG_MODE_ENABLED)
+  {
     mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
     mainCanvas.setTextSize(1);
     mainCanvas.setCursor(5, LCD_HEIGHT - 12);
@@ -175,8 +189,8 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
 // ────────────────────── 油温バー描画 ──────────────────────
 void drawOilTemperatureTopBar(M5Canvas& canvas, int oilTemp, int maxOilTemp)
 {
-  constexpr int MIN_TEMP   =  80;
-  constexpr int MAX_TEMP   = 130;
+  constexpr int MIN_TEMP = 80;
+  constexpr int MAX_TEMP = 130;
   constexpr int ALERT_TEMP = 120;
 
   constexpr int X = 20, Y = 15, W = 210, H = 20;
@@ -185,7 +199,8 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, int oilTemp, int maxOilTemp)
   // 水温ゲージと同じグレー背景を描画
   canvas.fillRect(X + 1, Y + 1, W - 2, H - 2, 0x18E3);
 
-  if (oilTemp >= MIN_TEMP) {
+  if (oilTemp >= MIN_TEMP)
+  {
     int barWidth = static_cast<int>(W * (oilTemp - MIN_TEMP) / RANGE);
     uint32_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
     canvas.fillRect(X, Y, barWidth, H, barColor);
@@ -196,18 +211,19 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, int oilTemp, int maxOilTemp)
   canvas.setTextColor(COLOR_WHITE);
   canvas.setFont(&fonts::Font0);
 
-  for (int m : marks) {
+  for (int m : marks)
+  {
     int tx = X + static_cast<int>(W * (m - MIN_TEMP) / RANGE);
     canvas.drawPixel(tx, Y - 2, COLOR_WHITE);
     canvas.setCursor(tx - 10, Y - 14);
     canvas.printf("%d", m);
-    if (m == ALERT_TEMP)
-      canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
+    if (m == ALERT_TEMP) canvas.drawLine(tx, Y, tx, Y + H - 2, COLOR_GRAY);
   }
 
   canvas.setCursor(X, Y + H + 4);
   canvas.printf("OIL.T / Celsius,  MAX:%03d", maxOilTemp);
-  char tempStr[6]; sprintf(tempStr, "%d", oilTemp);
+  char tempStr[6];
+  sprintf(tempStr, "%d", oilTemp);
   canvas.setFont(&FreeSansBold24pt7b);
   canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
 }
@@ -241,22 +257,24 @@ void setup()
 
   M5.Speaker.begin();
   M5.Imu.begin();
-  btStop();   // Bluetooth OFF
+  btStop();  // Bluetooth OFF
 
   pinMode(9, INPUT_PULLUP);
   pinMode(8, INPUT_PULLUP);
   Wire.begin(9, 8);
 
-  if (!adsConverter.begin()) {
+  if (!adsConverter.begin())
+  {
     Serial.println("[ADS1015] init failed… all analog values will be 0");
   }
   adsConverter.setDataRate(RATE_ADS1015_1600SPS);
 
-  if (SENSOR_AMBIENT_LIGHT_PRESENT) {
+  if (SENSOR_AMBIENT_LIGHT_PRESENT)
+  {
     // LTR553 初期化（サンプルでは begin() 呼び出しが推奨されている）
     CoreS3.Ltr553.begin(&ltr553InitParams);
     CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
-    ltr553InitParams.als_gain             = LTR5XX_ALS_GAIN_48X;
+    ltr553InitParams.als_gain = LTR5XX_ALS_GAIN_48X;
     ltr553InitParams.als_integration_time = LTR5XX_ALS_INTEGRATION_TIME_300MS;
   }
 }
@@ -276,8 +294,10 @@ uint32_t measureLuxWithoutBacklight()
 
 void updateBacklightLevel()
 {
-  if (!SENSOR_AMBIENT_LIGHT_PRESENT) {
-    if (currentBrightnessMode != BrightnessMode::Day) {
+  if (!SENSOR_AMBIENT_LIGHT_PRESENT)
+  {
+    if (currentBrightnessMode != BrightnessMode::Day)
+    {
       currentBrightnessMode = BrightnessMode::Day;
       display.setBrightness(BACKLIGHT_DAY);
     }
@@ -295,21 +315,21 @@ void updateBacklightLevel()
   std::nth_element(sorted, sorted + MEDIAN_BUFFER_SIZE / 2, sorted + MEDIAN_BUFFER_SIZE);
   uint32_t medianLux = sorted[MEDIAN_BUFFER_SIZE / 2];
 
-  BrightnessMode newMode =
-      (medianLux >= LUX_THRESHOLD_DAY)  ? BrightnessMode::Day  :
-      (medianLux >= LUX_THRESHOLD_DUSK) ? BrightnessMode::Dusk : BrightnessMode::Night;
+  BrightnessMode newMode = (medianLux >= LUX_THRESHOLD_DAY)    ? BrightnessMode::Day
+                           : (medianLux >= LUX_THRESHOLD_DUSK) ? BrightnessMode::Dusk
+                                                               : BrightnessMode::Night;
 
-  if (newMode != currentBrightnessMode) {
+  if (newMode != currentBrightnessMode)
+  {
     currentBrightnessMode = newMode;
-    uint8_t targetB =
-        (newMode == BrightnessMode::Day)  ? BACKLIGHT_DAY  :
-        (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK : BACKLIGHT_NIGHT;
+    uint8_t targetB = (newMode == BrightnessMode::Day)    ? BACKLIGHT_DAY
+                      : (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK
+                                                          : BACKLIGHT_NIGHT;
     display.setBrightness(targetB);
 
-    if (DEBUG_MODE_ENABLED) {
-      const char* s =
-          (newMode == BrightnessMode::Day)  ? "DAY"  :
-          (newMode == BrightnessMode::Dusk) ? "DUSK" : "NIGHT";
+    if (DEBUG_MODE_ENABLED)
+    {
+      const char* s = (newMode == BrightnessMode::Day) ? "DAY" : (newMode == BrightnessMode::Dusk) ? "DUSK" : "NIGHT";
       Serial.printf("[ALS] median=%lu → mode=%s → brightness=%u\n", medianLux, s, targetB);
     }
   }
@@ -319,56 +339,59 @@ void updateBacklightLevel()
 void acquireSensorData()
 {
   // 油圧
-  if (SENSOR_OIL_PRESSURE_PRESENT) {
-    int16_t raw = readAdcWithSettling(1);                  // CH1: 油圧
-    oilPressureSamples[oilPressureSampleIndex] =
-        convertVoltageToOilPressure(convertAdcToVoltage(raw));
-  } else {
+  if (SENSOR_OIL_PRESSURE_PRESENT)
+  {
+    int16_t raw = readAdcWithSettling(1);  // CH1: 油圧
+    oilPressureSamples[oilPressureSampleIndex] = convertVoltageToOilPressure(convertAdcToVoltage(raw));
+  }
+  else
+  {
     oilPressureSamples[oilPressureSampleIndex] = 0.0f;
   }
   oilPressureSampleIndex = (oilPressureSampleIndex + 1) % PRESSURE_SAMPLE_SIZE;
 
   // 水温
-  if (SENSOR_WATER_TEMP_PRESENT) {
-    int16_t raw = readAdcWithSettling(0);                  // CH0: 水温
-    waterTemperatureSamples[waterTemperatureSampleIndex] =
-        convertVoltageToTemp(convertAdcToVoltage(raw));
-  } else {
+  if (SENSOR_WATER_TEMP_PRESENT)
+  {
+    int16_t raw = readAdcWithSettling(0);  // CH0: 水温
+    waterTemperatureSamples[waterTemperatureSampleIndex] = convertVoltageToTemp(convertAdcToVoltage(raw));
+  }
+  else
+  {
     waterTemperatureSamples[waterTemperatureSampleIndex] = 0.0f;
   }
   waterTemperatureSampleIndex = (waterTemperatureSampleIndex + 1) % WATER_TEMP_SAMPLE_SIZE;
 
   // 油温
-  if (SENSOR_OIL_TEMP_PRESENT) {
-    int16_t raw = readAdcWithSettling(2);                  // CH2: 油温
-    oilTemperatureSamples[oilTemperatureSampleIndex] =
-        convertVoltageToTemp(convertAdcToVoltage(raw));
-  } else {
+  if (SENSOR_OIL_TEMP_PRESENT)
+  {
+    int16_t raw = readAdcWithSettling(2);  // CH2: 油温
+    oilTemperatureSamples[oilTemperatureSampleIndex] = convertVoltageToTemp(convertAdcToVoltage(raw));
+  }
+  else
+  {
     oilTemperatureSamples[oilTemperatureSampleIndex] = 0.0f;
   }
   oilTemperatureSampleIndex = (oilTemperatureSampleIndex + 1) % OIL_TEMP_SAMPLE_SIZE;
 
   // 最大値更新
-  recordedMaxOilPressure =
-      std::max(recordedMaxOilPressure, calculateAverage(oilPressureSamples));
-  recordedMaxWaterTemp   =
-      std::max(recordedMaxWaterTemp,   calculateAverage(waterTemperatureSamples));
+  recordedMaxOilPressure = std::max(recordedMaxOilPressure, calculateAverage(oilPressureSamples));
+  recordedMaxWaterTemp = std::max(recordedMaxWaterTemp, calculateAverage(waterTemperatureSamples));
 }
 
 // ────────────────────── メーター描画 ──────────────────────
 void updateGauges()
 {
-  float pressureAvg  = calculateAverage(oilPressureSamples);
+  float pressureAvg = calculateAverage(oilPressureSamples);
   float waterTempAvg = calculateAverage(waterTemperatureSamples);
-  float oilTempAvg   = calculateAverage(oilTemperatureSamples);
+  float oilTempAvg = calculateAverage(oilTemperatureSamples);
 
   int oilTempDisplay = static_cast<int>(oilTempAvg);
   if (!SENSOR_OIL_TEMP_PRESENT) oilTempDisplay = 0;
 
   recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, oilTempDisplay);
 
-  renderDisplayAndLog(pressureAvg, waterTempAvg,
-                      oilTempDisplay, recordedMaxOilTempTop);
+  renderDisplayAndLog(pressureAvg, waterTempAvg, oilTempDisplay, recordedMaxOilTempTop);
 }
 
 // ────────────────────── loop() ──────────────────────
@@ -377,7 +400,8 @@ void loop()
   static unsigned long previousAlsSampleTime = 0;
   unsigned long now = millis();
 
-  if (now - previousAlsSampleTime >= ALS_MEASUREMENT_INTERVAL_MS) {
+  if (now - previousAlsSampleTime >= ALS_MEASUREMENT_INTERVAL_MS)
+  {
     updateBacklightLevel();
     previousAlsSampleTime = now;
   }
@@ -386,10 +410,11 @@ void loop()
   updateGauges();
 
   frameCounterPerSecond++;
-  if (now - previousFpsTimestamp >= 1000UL) {
+  if (now - previousFpsTimestamp >= 1000UL)
+  {
     currentFramesPerSecond = frameCounterPerSecond;
     if (DEBUG_MODE_ENABLED) Serial.printf("FPS:%d\n", currentFramesPerSecond);
     frameCounterPerSecond = 0;
-    previousFpsTimestamp  = now;
+    previousFpsTimestamp = now;
   }
 }


### PR DESCRIPTION
## 概要 / Summary
- drawFillArcMeter に `drawTicks` 引数を追加し、動的更新時には目盛り類を再描画しないよう変更
- renderDisplayAndLog を更新し、初回のみ静的要素を描画するように修正

## テスト / Testing
- `platformio` をインストール後 `pio run -e m5stack-cores3` を実行しましたが、依存パッケージ取得時にネットワーク制限で失敗しました


------
https://chatgpt.com/codex/tasks/task_e_6850233e1db08322a18b67e33b1cbb0a