### PR TITLE
fix: keep red zone red

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -30,13 +30,13 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, 0, INACTIVE_COLOR);
 
   // レッドゾーンの背景を描画
-  // グレー背景と 1px 離すため、開始半径を -6、終了半径を -1 とする
+  // グレー背景から 1px 離すため外側半径を 1px 内側にずらす
   float redZoneStartAngle = -270 + ((threshold - minValue) / (maxValue - minValue) * 270.0);
   canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
-                 RADIUS - ARC_WIDTH - 6,               // 内側半径
-                 RADIUS - ARC_WIDTH - 1,               // 外側半径
+                 RADIUS - ARC_WIDTH - 5,  // 内側半径はそのまま
+                 RADIUS - ARC_WIDTH - 1,  // 外側半径を 1px 内側へ
                  redZoneStartAngle, 0,
-                 RED);                                 // 常に赤で表示
+                 RED);                   // 常に赤で表示
 
   // 現在の値に対応する部分を塗りつぶし
   if (value >= minValue && value <= maxValue * 1.1)

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -33,8 +33,8 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   // グレー背景から 1px 離すため外側半径を 1px 内側にずらす
   float redZoneStartAngle = -270 + ((threshold - minValue) / (maxValue - minValue) * 270.0);
   canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
-                 RADIUS - ARC_WIDTH - 5,  // 内側半径はそのまま
-                 RADIUS - ARC_WIDTH - 1,  // 外側半径を 1px 内側へ
+                 RADIUS - ARC_WIDTH - 9,  // 内側半径
+                 RADIUS - ARC_WIDTH - 4,  // 外側半径
                  redZoneStartAngle, 0,
                  RED);                   // 常に赤で表示
 

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -30,17 +30,13 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, 0, INACTIVE_COLOR);
 
   // レッドゾーンの背景を描画
+  // グレー背景と 1px 離すため、開始半径を -6、終了半径を -1 とする
   float redZoneStartAngle = -270 + ((threshold - minValue) / (maxValue - minValue) * 270.0);
-  if (value >= threshold)
-  {
-    canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH - 5, RADIUS - ARC_WIDTH, redZoneStartAngle, 0,
-                   YELLOW);
-  }
-  else
-  {
-    canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH - 5, RADIUS - ARC_WIDTH, redZoneStartAngle, 0,
-                   RED);
-  }
+  canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
+                 RADIUS - ARC_WIDTH - 6,               // 内側半径
+                 RADIUS - ARC_WIDTH - 1,               // 外側半径
+                 redZoneStartAngle, 0,
+                 RED);                                 // 常に赤で表示
 
   // 現在の値に対応する部分を塗りつぶし
   if (value >= minValue && value <= maxValue * 1.1)


### PR DESCRIPTION
## Summary / 概要
- レッドゾーンを常に赤表示に変更
- グレー背景と1px離した描画に調整

## Testing
- `pio run` *(failed: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850ecd0415883229d9bd9f79651ba32