### PR TITLE
perf: cache gauge static elements / メーター静的部分のキャッシュ

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -6,11 +6,12 @@
 #include <cmath>
 
 void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxValue, float threshold,
-                      uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,
-                      float tickStep,  // 目盛の間隔
-                      bool useDecimal,  // 小数点を表示するかどうか
-                      int x, int y
-)
+                       uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,
+                       float tickStep,  // 目盛の間隔
+                       bool useDecimal,  // 小数点を表示するかどうか
+                       int x, int y,
+                       bool drawStaticParts = true
+  )
 {
   const int CENTER_X_CORRECTED = x + 75 + 5;   // スプライト内の中心X座標
   const int CENTER_Y_CORRECTED = y + 90 - 10;  // スプライト内の中心Y座標
@@ -29,15 +30,18 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   // メーター全体を塗りつぶし（非アクティブ部分）
   canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, 0, INACTIVE_COLOR);
 
-  // レッドゾーンの背景を描画
-  // 背景グレーと 1px の隙間を空け常に赤で表示する
-  float redZoneStartAngle =
-      -270 + ((threshold - minValue) / (maxValue - minValue) * 270.0);
-  canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
-                 RADIUS - ARC_WIDTH - 9,  // 内側半径
-                 RADIUS - ARC_WIDTH - 4,  // 外側半径
-                 redZoneStartAngle, 0,
-                 RED);               // レッドゾーンは常に赤表示
+  if (drawStaticParts)
+  {
+    // レッドゾーンの背景を描画
+    // 背景グレーと 1px の隙間を空け常に赤で表示する
+    float redZoneStartAngle =
+        -270 + ((threshold - minValue) / (maxValue - minValue) * 270.0);
+    canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
+                   RADIUS - ARC_WIDTH - 9,  // 内側半径
+                   RADIUS - ARC_WIDTH - 4,  // 外側半径
+                   redZoneStartAngle, 0,
+                   RED);             // レッドゾーンは常に赤表示
+  }
 
   // 現在の値に対応する部分を塗りつぶし
   if (value >= minValue && value <= maxValue * 1.1)
@@ -70,35 +74,38 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
     );
   }
 
-  // 目盛ラベルと目盛り線を描画
-  int tickCount = static_cast<int>((maxValue - minValue) / tickStep) + 1;
-  for (float i = 0; i <= tickCount - 1; i += 1)
+  if (drawStaticParts)
   {
-    float scaledValue = minValue + (tickStep * i);
-    float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
-    float rad = radians(angle);
-
-    int lineX1 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 10));
-    int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 10));
-    int lineX2 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 5));
-    int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 5));
-
-    canvas.drawLine(lineX1, lineY1, lineX2, lineY2, WHITE);
-
-    // 整数値の目盛ラベルを描画
-    if (fmod(scaledValue, 1.0) == 0)
+    // 目盛ラベルと目盛り線を描画
+    int tickCount = static_cast<int>((maxValue - minValue) / tickStep) + 1;
+    for (float i = 0; i <= tickCount - 1; i += 1)
     {
-      int labelX = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 15));
-      int labelY = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 15));
+      float scaledValue = minValue + (tickStep * i);
+      float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
+      float rad = radians(angle);
 
-      char labelText[6];
-      snprintf(labelText, sizeof(labelText), "%.0f", scaledValue);
+      int lineX1 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 10));
+      int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 10));
+      int lineX2 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 5));
+      int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 5));
 
-      canvas.setTextFont(1);
-      canvas.setFont(&fonts::Font0);
-      canvas.setTextColor(TEXT_COLOR, BACKGROUND_COLOR);
-      canvas.setCursor(labelX - (canvas.textWidth(labelText) / 2), labelY - 4);
-      canvas.print(labelText);
+      canvas.drawLine(lineX1, lineY1, lineX2, lineY2, WHITE);
+
+      // 整数値の目盛ラベルを描画
+      if (fmod(scaledValue, 1.0) == 0)
+      {
+        int labelX = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 15));
+        int labelY = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 15));
+
+        char labelText[6];
+        snprintf(labelText, sizeof(labelText), "%.0f", scaledValue);
+
+        canvas.setTextFont(1);
+        canvas.setFont(&fonts::Font0);
+        canvas.setTextColor(TEXT_COLOR, BACKGROUND_COLOR);
+        canvas.setCursor(labelX - (canvas.textWidth(labelText) / 2), labelY - 4);
+        canvas.print(labelText);
+      }
     }
   }
 
@@ -119,14 +126,17 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   canvas.setCursor(valueX - canvas.textWidth(valueText), valueY - (canvas.fontHeight() / 2));
   canvas.print(valueText);
 
-  // 単位とメーター名を表示
-  char combinedLabel[30];
-  snprintf(combinedLabel, sizeof(combinedLabel), "%s / %s", label, unit);
-  canvas.setFont(&fonts::Font0);
-  int labelX = CENTER_X_CORRECTED;
-  int labelY = CENTER_Y_CORRECTED + RADIUS + 15;
-  canvas.setCursor(labelX - (canvas.textWidth(combinedLabel) / 2), labelY);
-  canvas.print(combinedLabel);
+  if (drawStaticParts)
+  {
+    // 単位とメーター名を表示
+    char combinedLabel[30];
+    snprintf(combinedLabel, sizeof(combinedLabel), "%s / %s", label, unit);
+    canvas.setFont(&fonts::Font0);
+    int labelX = CENTER_X_CORRECTED;
+    int labelY = CENTER_Y_CORRECTED + RADIUS + 15;
+    canvas.setCursor(labelX - (canvas.textWidth(combinedLabel) / 2), labelY);
+    canvas.print(combinedLabel);
+  }
 }
 
 #endif // DRAW_FILL_ARC_METER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,11 @@ unsigned long previousFpsTimestamp   = 0;
 int           frameCounterPerSecond  = 0;
 int           currentFramesPerSecond = 0;
 
+// ── 静的描画フラグ ──
+bool pressureGaugeStaticDrawn = false;
+bool waterGaugeStaticDrawn    = false;
+int  prevWaterTempDigits      = 0;
+
 // ────────────────────── プロトタイプ ──────────────────────
 void drawOilTemperatureTopBar(M5Canvas& canvas, int oilTemp, int maxOilTemp);
 void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
@@ -154,18 +159,28 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
   }
 
   if (pressureChanged) {
-    mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+    bool drawStatic = !pressureGaugeStaticDrawn;
+    if (drawStatic) {
+      mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+    }
     drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_DISPLAY,  8.0f,
                      RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                     0.5f, true,   0,   60);
+                     0.5f, true,   0,   60, drawStatic);
+    pressureGaugeStaticDrawn = true;
     displayCache.pressureAvg = pressureAvg;
   }
 
   if (waterChanged) {
-    mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+    int digits = (waterTempAvg >= 100.0f) ? 3 : 2;
+    bool drawStatic = !waterGaugeStaticDrawn || (prevWaterTempDigits == 3 && digits == 2);
+    if (drawStatic) {
+      mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+    }
     drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f,110.0f, 98.0f,
                      RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                     5.0f, false, 160,  60);
+                     5.0f, false, 160,  60, drawStatic);
+    waterGaugeStaticDrawn = true;
+    prevWaterTempDigits = digits;
     displayCache.waterTempAvg = waterTempAvg;
   }
 


### PR DESCRIPTION
## Summary
- cache gauge tick marks and labels to avoid redrawing
- redraw when water temp digits shrink from 3 to 2

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514948f88483229174f71aa71e1b03