### PR TITLE
Improve gauge rendering behavior

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -5,11 +5,19 @@
 #include <algorithm>
 #include <cmath>
 
+// 描画状態保持用構造体
+struct GaugeRenderState {
+  bool  firstDraw      = true;                                  // 初回描画かどうか
+  float previousValue  = std::numeric_limits<float>::quiet_NaN();
+  int   previousDigits = 0;                                     // 前回描画時の桁数
+};
+
 void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxValue, float threshold,
                       uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,
                       float tickStep,  // 目盛の間隔
                       bool useDecimal,  // 小数点を表示するかどうか
-                      int x, int y
+                      int x, int y,
+                      GaugeRenderState &state
 )
 {
   const int CENTER_X_CORRECTED = x + 75 + 5;   // スプライト内の中心X座標
@@ -21,23 +29,58 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   const uint16_t ACTIVE_COLOR = WHITE;                    // 現在の値の色
   const uint16_t INACTIVE_COLOR = 0x18E3;                 // メーター全体の背景色
   const uint16_t TEXT_COLOR = WHITE;                      // テキストの色
-  const uint16_t MAX_VALUE_COLOR = RED;                   // 最大値の印の色
 
   // 最大値を更新
   maxRecordedValue = std::max(value, maxRecordedValue);
 
-  // メーター全体を塗りつぶし（非アクティブ部分）
-  canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, 0, INACTIVE_COLOR);
+  // 値が減少した場合はメーター部をクリア
+  if (state.firstDraw || (!std::isnan(state.previousValue) && value < state.previousValue)) {
+    canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
+                   RADIUS - ARC_WIDTH, RADIUS,
+                   -270, 0, INACTIVE_COLOR);
+  }
 
-  // レッドゾーンの背景を描画
-  // 背景グレーと 1px の隙間を空け常に赤で表示する
-  float redZoneStartAngle =
-      -270 + ((threshold - minValue) / (maxValue - minValue) * 270.0);
-  canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
-                 RADIUS - ARC_WIDTH - 9,  // 内側半径
-                 RADIUS - ARC_WIDTH - 4,  // 外側半径
-                 redZoneStartAngle, 0,
-                 RED);               // レッドゾーンは常に赤表示
+  // 初回のみレッドゾーンと目盛りを描画
+  if (state.firstDraw) {
+    float redZoneStartAngle =
+        -270 + ((threshold - minValue) / (maxValue - minValue) * 270.0);
+    canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED,
+                   RADIUS - ARC_WIDTH - 9,  // 内側半径
+                   RADIUS - ARC_WIDTH - 4,  // 外側半径
+                   redZoneStartAngle, 0,
+                   RED);               // レッドゾーンは常に赤表示
+
+    int tickCount = static_cast<int>((maxValue - minValue) / tickStep) + 1;
+    for (float i = 0; i <= tickCount - 1; i += 1)
+    {
+      float scaledValue = minValue + (tickStep * i);
+      float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
+      float rad = radians(angle);
+
+      int lineX1 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 10));
+      int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 10));
+      int lineX2 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 5));
+      int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 5));
+
+      canvas.drawLine(lineX1, lineY1, lineX2, lineY2, WHITE);
+
+      // 整数値の目盛ラベルを描画
+      if (fmod(scaledValue, 1.0) == 0)
+      {
+        int labelX = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 15));
+        int labelY = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 15));
+
+        char labelText[6];
+        snprintf(labelText, sizeof(labelText), "%.0f", scaledValue);
+
+        canvas.setTextFont(1);
+        canvas.setFont(&fonts::Font0);
+        canvas.setTextColor(TEXT_COLOR, BACKGROUND_COLOR);
+        canvas.setCursor(labelX - (canvas.textWidth(labelText) / 2), labelY - 4);
+        canvas.print(labelText);
+      }
+    }
+  }
 
   // 現在の値に対応する部分を塗りつぶし
   if (value >= minValue && value <= maxValue * 1.1)
@@ -47,60 +90,7 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
     canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, valueAngle, barColor);
   }
 
-  // 最大値の印を表示
-  if (maxRecordedValue > minValue && maxRecordedValue <= maxValue)
-  {
-    float maxValueAngle = 270 - ((270.0 / (maxValue - minValue)) * (maxRecordedValue - minValue));  // 最大値を角度に変換
 
-    // 三角形の先端（外側）
-    float maxMarkX = CENTER_X_CORRECTED + (cos(radians(maxValueAngle)) * (RADIUS + 5));
-    float maxMarkY = CENTER_Y_CORRECTED - (sin(radians(maxValueAngle)) * (RADIUS + 5));
-
-    // 小さな三角形の基点（外側に配置）
-    float baseMarkX1 = CENTER_X_CORRECTED + (cos(radians(maxValueAngle + 3)) * (RADIUS + 8));
-    float baseMarkY1 = CENTER_Y_CORRECTED - (sin(radians(maxValueAngle + 3)) * (RADIUS + 8));
-
-    float baseMarkX2 = CENTER_X_CORRECTED + (cos(radians(maxValueAngle - 3)) * (RADIUS + 8));
-    float baseMarkY2 = CENTER_Y_CORRECTED - (sin(radians(maxValueAngle - 3)) * (RADIUS + 8));
-
-    canvas.fillTriangle(maxMarkX, maxMarkY,      // 三角形の先端（外側の位置）
-                        baseMarkX1, baseMarkY1,  // 三角形の左基点
-                        baseMarkX2, baseMarkY2,  // 三角形の右基点
-                        MAX_VALUE_COLOR          // 最大値の色
-    );
-  }
-
-  // 目盛ラベルと目盛り線を描画
-  int tickCount = static_cast<int>((maxValue - minValue) / tickStep) + 1;
-  for (float i = 0; i <= tickCount - 1; i += 1)
-  {
-    float scaledValue = minValue + (tickStep * i);
-    float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
-    float rad = radians(angle);
-
-    int lineX1 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 10));
-    int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 10));
-    int lineX2 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 5));
-    int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 5));
-
-    canvas.drawLine(lineX1, lineY1, lineX2, lineY2, WHITE);
-
-    // 整数値の目盛ラベルを描画
-    if (fmod(scaledValue, 1.0) == 0)
-    {
-      int labelX = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 15));
-      int labelY = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 15));
-
-      char labelText[6];
-      snprintf(labelText, sizeof(labelText), "%.0f", scaledValue);
-
-      canvas.setTextFont(1);
-      canvas.setFont(&fonts::Font0);
-      canvas.setTextColor(TEXT_COLOR, BACKGROUND_COLOR);
-      canvas.setCursor(labelX - (canvas.textWidth(labelText) / 2), labelY - 4);
-      canvas.print(labelText);
-    }
-  }
 
   // 値を右下に表示
   char valueText[10];
@@ -116,6 +106,18 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   canvas.setFont(&FreeSansBold24pt7b);
   int valueX = CENTER_X_CORRECTED + RADIUS + 10;
   int valueY = CENTER_Y_CORRECTED + RADIUS - 20;
+
+  // 表示領域を一度クリア
+  char maxStr[6];
+  if (useDecimal)
+    strcpy(maxStr, "00.0");
+  else
+    strcpy(maxStr, "000");
+  int clearW = canvas.textWidth(maxStr) + 4;
+  int clearH = canvas.fontHeight();
+  canvas.fillRect(valueX - clearW, valueY - clearH, clearW, clearH, BACKGROUND_COLOR);
+
+  canvas.setTextColor(TEXT_COLOR);
   canvas.setCursor(valueX - canvas.textWidth(valueText), valueY - (canvas.fontHeight() / 2));
   canvas.print(valueText);
 
@@ -127,6 +129,13 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   int labelY = CENTER_Y_CORRECTED + RADIUS + 15;
   canvas.setCursor(labelX - (canvas.textWidth(combinedLabel) / 2), labelY);
   canvas.print(combinedLabel);
+
+  // 状態を更新
+  state.firstDraw = false;
+  state.previousValue = value;
+  if (!useDecimal) {
+    state.previousDigits = (static_cast<int>(value) >= 100) ? 3 : 2;
+  }
 }
 
 #endif // DRAW_FILL_ARC_METER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,10 @@ float recordedMaxOilPressure = 0.0f;
 float recordedMaxWaterTemp   = 0.0f;
 int   recordedMaxOilTempTop  = 0;
 
+// メーター描画状態
+GaugeRenderState pressureGaugeState;
+GaugeRenderState waterGaugeState;
+
 // ── 表示キャッシュ ──
 struct DisplayCache {
   float  pressureAvg;
@@ -157,15 +161,19 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
     drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_DISPLAY,  8.0f,
                      RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                     0.5f, true,   0,   60);
+                     0.5f, true,   0,   60, pressureGaugeState);
     displayCache.pressureAvg = pressureAvg;
   }
 
-  if (waterChanged) {
+  int waterDigits = (static_cast<int>(waterTempAvg) >= 100) ? 3 : 2;
+  bool waterRedraw = (waterGaugeState.previousDigits == 3 && waterDigits == 2);
+
+  if (waterChanged || waterRedraw) {
     mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+    if (waterRedraw) waterGaugeState.firstDraw = true;
     drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f,110.0f, 98.0f,
                      RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                     5.0f, false, 160,  60);
+                     5.0f, false, 160,  60, waterGaugeState);
     displayCache.waterTempAvg = waterTempAvg;
   }
 


### PR DESCRIPTION
## Summary
- remove max value triangle marker
- only draw gauge tick marks/red zone once
- clear numeric area before each update
- redraw water temp gauge when digit count shrinks

## Testing
- `pio run -t nobuild` *(fails: platform package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851522176488322a73046f85c6b6645