### PR TITLE
fix: adjust oil pressure range

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -29,9 +29,11 @@ constexpr uint16_t COLOR_YELLOW = rgb565(255, 255, 0);
 constexpr uint16_t COLOR_RED    = rgb565(255,   0, 0);
 constexpr uint16_t COLOR_GRAY   = rgb565(169, 169, 169);
 
-// ── 油圧表示上限 ──
-// メーターおよび数値表示が 9.9 bar を超えないようにする
-constexpr float MAX_OIL_PRESSURE_DISPLAY = 9.9f;
+// ── 油圧の表示設定 ──
+// 数値表示の上限 (バー単位)
+constexpr float MAX_OIL_PRESSURE_DISPLAY = 15.0f;
+// メーター目盛の上限
+constexpr float MAX_OIL_PRESSURE_METER   = 10.0f;
 
 // ── 画面サイズ ──
 constexpr int LCD_WIDTH  = 320;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
 
   if (pressureChanged) {
     mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
-    drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_DISPLAY,  8.0f,
+    drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_METER,  8.0f,
                      RED, "BAR", "OIL.P", recordedMaxOilPressure,
                      0.5f, true,   0,   60);
     displayCache.pressureAvg = pressureAvg;


### PR DESCRIPTION
## Summary
- 油圧の数値表示上限を 15 bar まで拡張
- メーター目盛は 10 bar のままに変更

## Testing
- `platformio run -e m5stack-cores3` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68523eacb4d88322b741ff87d4d4b493