### PR TITLE
Add red zone for low oil pressure / 油圧0.3以下を赤表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# M5Stack CoreS3 Multi-Gauge  
+# M5Stack CoreS3 Multi-Gauge
 # M5Stack CoreS3 マルチメーター
 
 A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays:
@@ -21,7 +21,8 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 ### 主な機能
 - 油圧・燃圧・ブースト (0–9.9 bar) 半円アナログメーター
   - 本リポジトリでは **油圧**・**油温** を実装済み
-- 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
+  - 油圧が 8 bar 以上、または 0.3 bar 以下でメーターが赤色表示
+- 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示
 - 各種設定は `include/config.h` の定数で変更可能
 
 ### ハードウェア構成
@@ -51,6 +52,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 ### Features
 - Semi-circular analog gauge (0–9.9 bar, pressure)
   - In this repository, **oil pressure** and **oil temperature** are implemented.
+  - Gauge turns red at 8 bar or above, and also below 0.3 bar
 - Digital + bar graph temperature display
 - Most settings are in `include/config.h`
 

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -5,12 +5,14 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxValue, float threshold,
                       uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,
                       float tickStep,   // 目盛の間隔
                       bool useDecimal,  // 小数点を表示するかどうか
-                      int x, int y)
+                      int x, int y, float lowThreshold = std::numeric_limits<float>::lowest(),
+                      uint16_t belowThresholdColor = RED)
 {
   const int CENTER_X_CORRECTED = x + 75 + 5;   // スプライト内の中心X座標
   const int CENTER_Y_CORRECTED = y + 90 - 10;  // スプライト内の中心Y座標
@@ -48,7 +50,13 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   // クランプ後の値でバーを描画
   if (clampedValue >= minValue)
   {
-    uint16_t barColor = (value >= threshold) ? overThresholdColor : ACTIVE_COLOR;
+    // 上限・下限の閾値に応じて色を決める
+    uint16_t barColor = ACTIVE_COLOR;
+    if (value >= threshold)
+      barColor = overThresholdColor;
+    else if (value <= lowThreshold)
+      barColor = belowThresholdColor;
+
     float valueAngle = -270 + ((clampedValue - minValue) / (maxValue - minValue) * 270.0);
     canvas.fillArc(CENTER_X_CORRECTED, CENTER_Y_CORRECTED, RADIUS - ARC_WIDTH, RADIUS, -270, valueAngle, barColor);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,8 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
     drawFillArcMeter(mainCanvas, pressureAvg,  0.0f, MAX_OIL_PRESSURE_METER,  8.0f,
                      RED, "BAR", "OIL.P", recordedMaxOilPressure,
-                     0.5f, true,   0,   60);
+                     0.5f, true,   0,   60,
+                     0.3f, RED);
     displayCache.pressureAvg = pressureAvg;
   }
 


### PR DESCRIPTION
## Summary
- gauge color function now supports low limit
- paint oil pressure gauge red when below 0.3 bar
- mention red alert range in README

## Testing
- `pio run -e m5stack-cores3` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68529eb845b88322b62522a4eab99976