### PR TITLE
Fix oil temperature bar width / 油温バーの幅を正しく制限

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,7 +208,9 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, int oilTemp, int maxOilTemp)
   canvas.fillRect(X + 1, Y + 1, W - 2, H - 2, 0x18E3);
 
   if (oilTemp >= MIN_TEMP) {
-    int barWidth = static_cast<int>(W * (oilTemp - MIN_TEMP) / RANGE);
+    // 値が範囲外の場合はバー幅が画面外にはみ出さないようにクランプ
+    int clampedTemp = std::min(std::max(oilTemp, MIN_TEMP), MAX_TEMP);
+    int barWidth = static_cast<int>(W * (clampedTemp - MIN_TEMP) / RANGE);
     uint32_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
     canvas.fillRect(X, Y, barWidth, H, barColor);
   }


### PR DESCRIPTION
## Summary
- clamp oil temperature bar width so it doesn't overflow

## 概要
- 油温バーの幅が画面外へはみ出さないように制限しました


------
https://chatgpt.com/codex/tasks/task_e_6853fcceab308322a4433926913e409e