### PR TITLE
feat: water temperature gauge ticks

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -36,8 +36,9 @@ constexpr float MAX_OIL_PRESSURE_DISPLAY = 15.0f;
 constexpr float MAX_OIL_PRESSURE_METER   = 10.0f;
 
 // ── 水温メーター設定 ──
-constexpr float WATER_TEMP_METER_MIN = 80.0f;  // 水温メーター下限
-constexpr float WATER_TEMP_METER_MAX = 110.0f; // 水温メーター上限
+// 水温メーター下限と上限を80℃〜105℃に設定
+constexpr float WATER_TEMP_METER_MIN = 80.0f;
+constexpr float WATER_TEMP_METER_MAX = 105.0f;
 
 // ── 画面サイズ ──
 constexpr int LCD_WIDTH  = 320;

--- a/include/config.h
+++ b/include/config.h
@@ -35,6 +35,10 @@ constexpr float MAX_OIL_PRESSURE_DISPLAY = 15.0f;
 // メーター目盛の上限
 constexpr float MAX_OIL_PRESSURE_METER   = 10.0f;
 
+// ── 水温メーター設定 ──
+constexpr float WATER_TEMP_METER_MIN = 80.0f;  // 水温メーター下限
+constexpr float WATER_TEMP_METER_MAX = 110.0f; // 水温メーター上限
+
 // ── 画面サイズ ──
 constexpr int LCD_WIDTH  = 320;
 constexpr int LCD_HEIGHT = 240;

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -106,6 +106,11 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
 
         canvas.setTextFont(1);
         canvas.setFont(&fonts::Font0);
+        // 90℃と100℃のラベルだけ少し大きく描画
+        if (fabsf(scaledValue - 90.0f) < 0.1f || fabsf(scaledValue - 100.0f) < 0.1f)
+          canvas.setTextSize(2);
+        else
+          canvas.setTextSize(1);
         canvas.setTextColor(TEXT_COLOR, BACKGROUND_COLOR);
         canvas.setCursor(labelX - (canvas.textWidth(labelText) / 2), labelY - 4);
         canvas.print(labelText);

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -71,23 +71,30 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
       float angle = 270 - ((270.0 / (tickCount - 1)) * i);  // 開始位置のロジックを維持
       float rad = radians(angle);
 
-      int lineX1 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 10));
-      int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 10));
-      int lineX2 = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 5));
-      int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 5));
-
-      canvas.drawLine(lineX1, lineY1, lineX2, lineY2, COLOR_WHITE);
-
-      bool drawLabel;
+      // 主要目盛かどうかを判定（majorTickStep が負なら従来と同じ判定）
+      bool isMajorTick;
       if (majorTickStep < 0)
       {
-        drawLabel = (fmod(scaledValue, 1.0f) == 0.0f);
+        isMajorTick = (fmod(scaledValue, 1.0f) == 0.0f);
       }
       else
       {
         float diff = fmod(scaledValue - labelStart, majorTickStep);
-        drawLabel = (scaledValue >= labelStart) && (fabsf(diff) < 0.01f || fabsf(diff - majorTickStep) < 0.01f);
+        isMajorTick = (scaledValue >= labelStart) && (fabsf(diff) < 0.01f || fabsf(diff - majorTickStep) < 0.01f);
       }
+
+      // 主要目盛は長めの線、細かい目盛は短めの線を描画
+      int innerRadius = isMajorTick ? (RADIUS - ARC_WIDTH - 10) : (RADIUS - ARC_WIDTH - 8);
+      int outerRadius = isMajorTick ? (RADIUS - ARC_WIDTH - 5)  : (RADIUS - ARC_WIDTH - 7);
+
+      int lineX1 = CENTER_X_CORRECTED + (cos(rad) * innerRadius);
+      int lineY1 = CENTER_Y_CORRECTED - (sin(rad) * innerRadius);
+      int lineX2 = CENTER_X_CORRECTED + (cos(rad) * outerRadius);
+      int lineY2 = CENTER_Y_CORRECTED - (sin(rad) * outerRadius);
+
+      canvas.drawLine(lineX1, lineY1, lineX2, lineY2, COLOR_WHITE);
+
+      bool drawLabel = isMajorTick;
 
       if (drawLabel)
       {

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -8,10 +8,12 @@
 
 void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxValue, float threshold,
                       uint16_t overThresholdColor, const char *unit, const char *label, float &maxRecordedValue,
-                      float tickStep,   // 目盛の間隔
+                      float tickStep,   // 目盛の間隔（細かい目盛り）
                       bool useDecimal,  // 小数点を表示するかどうか
                       int x, int y,
-                      bool drawStatic)
+                      bool drawStatic,
+                      float majorTickStep = -1.0f, // 数字を表示する目盛間隔（負なら旧仕様）
+                      float labelStart    = 0.0f)  // ラベル描画を開始する値
 {
   // 左端を 1px 固定しつつ数値表示位置は従来通りに保つ
   const int GAUGE_LEFT = x + 1;                    // 円メーターの左端
@@ -76,8 +78,18 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
 
       canvas.drawLine(lineX1, lineY1, lineX2, lineY2, COLOR_WHITE);
 
-      // 整数値の目盛ラベルを描画
-      if (fmod(scaledValue, 1.0) == 0)
+      bool drawLabel;
+      if (majorTickStep < 0)
+      {
+        drawLabel = (fmod(scaledValue, 1.0f) == 0.0f);
+      }
+      else
+      {
+        float diff = fmod(scaledValue - labelStart, majorTickStep);
+        drawLabel = (scaledValue >= labelStart) && (fabsf(diff) < 0.01f || fabsf(diff - majorTickStep) < 0.01f);
+      }
+
+      if (drawLabel)
       {
         int labelX = CENTER_X_CORRECTED + (cos(rad) * (RADIUS - ARC_WIDTH - 15));
         int labelY = CENTER_Y_CORRECTED - (sin(rad) * (RADIUS - ARC_WIDTH - 15));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,7 +176,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     }
     drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f,
                      COLOR_RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                     2.5f, false, 160,  60,
+                     1.0f, false, 160,  60,
                      !waterGaugeInitialized,
                      5.0f, WATER_TEMP_METER_MIN);
     waterGaugeInitialized = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,11 +174,11 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     if (!waterGaugeInitialized) {
       mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
     }
-    drawFillArcMeter(mainCanvas, waterTempAvg, 80.0f,110.0f, 98.0f,
+    drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f,
                      COLOR_RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
                      2.5f, false, 160,  60,
                      !waterGaugeInitialized,
-                     5.0f, 80.0f);
+                     5.0f, WATER_TEMP_METER_MIN);
     waterGaugeInitialized = true;
     displayCache.waterTempAvg = waterTempAvg;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,8 +176,9 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     }
     drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f,110.0f, 98.0f,
                      COLOR_RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                     5.0f, false, 160,  60,
-                     !waterGaugeInitialized);
+                     2.5f, false, 160,  60,
+                     !waterGaugeInitialized,
+                     5.0f, 80.0f);
     waterGaugeInitialized = true;
     displayCache.waterTempAvg = waterTempAvg;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     if (!waterGaugeInitialized) {
       mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
     }
-    drawFillArcMeter(mainCanvas, waterTempAvg, 50.0f,110.0f, 98.0f,
+    drawFillArcMeter(mainCanvas, waterTempAvg, 80.0f,110.0f, 98.0f,
                      COLOR_RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
                      2.5f, false, 160,  60,
                      !waterGaugeInitialized,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,7 +176,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     }
     drawFillArcMeter(mainCanvas, waterTempAvg, WATER_TEMP_METER_MIN, WATER_TEMP_METER_MAX, 98.0f,
                      COLOR_RED, "Celsius", "WATER.T", recordedMaxWaterTemp,
-                     1.0f, false, 160,  60,
+                     2.5f, false, 160,  60,
                      !waterGaugeInitialized,
                      5.0f, WATER_TEMP_METER_MIN);
     waterGaugeInitialized = true;


### PR DESCRIPTION
## Summary
- add parameters for custom tick labelling in drawFillArcMeter
- start water temperature tick labels at 80°C with 5-degree increments and 2.5-degree minor ticks

## Testing
- `platformio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6853fdad8f548322b491ed802b0caa80


* 動作確認OK