### PR TITLE
Adjust oil temp bar color / 油温バーの色調整

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,8 +210,22 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
 
   if (oilTemp >= MIN_TEMP) {
     int barWidth = static_cast<int>(W * (oilTemp - MIN_TEMP) / RANGE);
-    uint32_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
-    canvas.fillRect(X, Y, barWidth, H, barColor);
+    barWidth = std::min(barWidth, W);
+
+    // レッドゾーンに到達するまでの幅を計算
+    int thresholdWidth = static_cast<int>(W * (ALERT_TEMP - MIN_TEMP) / RANGE);
+    int normalWidth    = std::min(barWidth, thresholdWidth);
+
+    // 通常領域は白で塗りつぶす
+    if (normalWidth > 0) {
+      canvas.fillRect(X, Y, normalWidth, H, COLOR_WHITE);
+    }
+
+    // レッドゾーンに入った部分だけ赤で塗りつぶす
+    if (barWidth > thresholdWidth) {
+      int redWidth = barWidth - thresholdWidth;
+      canvas.fillRect(X + thresholdWidth, Y, redWidth, H, COLOR_RED);
+    }
   }
 
   const int marks[] = {80, 90, 100, 110, 120, 130};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,14 +210,6 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
 
   if (oilTemp >= MIN_TEMP) {
     int barWidth = static_cast<int>(W * (oilTemp - MIN_TEMP) / RANGE);
-    if (oilTemp >= ALERT_TEMP) {
-      // レッドゾーンに入ったらバーを全幅赤で表示する
-      barWidth = W;
-    } else {
-      // 通常時は温度に応じた幅で白色表示
-      barWidth = std::min(barWidth, W);
-    }
-
     // 16bit カラーで描画
     uint16_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
     canvas.fillRect(X, Y, barWidth, H, barColor);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,10 +210,16 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
 
   if (oilTemp >= MIN_TEMP) {
     int barWidth = static_cast<int>(W * (oilTemp - MIN_TEMP) / RANGE);
-    barWidth = std::min(barWidth, W);
+    if (oilTemp >= ALERT_TEMP) {
+      // レッドゾーンに入ったらバーを全幅赤で表示する
+      barWidth = W;
+    } else {
+      // 通常時は温度に応じた幅で白色表示
+      barWidth = std::min(barWidth, W);
+    }
 
-    // 通常時は白、レッドゾーンに入ったらバー全体を赤で描画
-    uint32_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
+    // 16bit カラーで描画
+    uint16_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
     canvas.fillRect(X, Y, barWidth, H, barColor);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,20 +212,9 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
     int barWidth = static_cast<int>(W * (oilTemp - MIN_TEMP) / RANGE);
     barWidth = std::min(barWidth, W);
 
-    // レッドゾーンに到達するまでの幅を計算
-    int thresholdWidth = static_cast<int>(W * (ALERT_TEMP - MIN_TEMP) / RANGE);
-    int normalWidth    = std::min(barWidth, thresholdWidth);
-
-    // 通常領域は白で塗りつぶす
-    if (normalWidth > 0) {
-      canvas.fillRect(X, Y, normalWidth, H, COLOR_WHITE);
-    }
-
-    // レッドゾーンに入った部分だけ赤で塗りつぶす
-    if (barWidth > thresholdWidth) {
-      int redWidth = barWidth - thresholdWidth;
-      canvas.fillRect(X + thresholdWidth, Y, redWidth, H, COLOR_RED);
-    }
+    // 通常時は白、レッドゾーンに入ったらバー全体を赤で描画
+    uint32_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
+    canvas.fillRect(X, Y, barWidth, H, barColor);
   }
 
   const int marks[] = {80, 90, 100, 110, 120, 130};


### PR DESCRIPTION
## Summary / 概要
- show normal part of oil temperature bar in white
- render only the overheat portion in red

## Testing
- `platformio run` *(failed: could not download packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6854037bdf8483228493a6d9bd3693c5