### PR TITLE
Improve FPS by configurable CPU speed / CPUクロック設定でFPS向上

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
   - 本リポジトリでは **油圧**・**油温** を実装済み
 - 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
 - 各種設定は `include/config.h` の定数で変更可能
+- `CPU_FREQ_MHZ` を調整して FPS を向上可能
 
 ### ハードウェア構成
 | モジュール       | 型番 / 仕様                       | 備考                     |
@@ -33,6 +34,7 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 | 温度センサ1      | **PDF00703S** (Defi)              | CH1 / 0.5 – 4.5 V        |
 | 温度センサ2      | **PDF00703S** (Defi)              | CH2 / 0.5 – 4.5 V        |
 | 電源             | 5V                               | CoreS3 USB経由           |
+| CPUクロック  | 240 MHz        | `include/config.h`で設定 |
 
 > 📌 詳しい配線図は後日追加予定です。
 
@@ -53,6 +55,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
   - In this repository, **oil pressure** and **oil temperature** are implemented.
 - Digital + bar graph temperature display
 - Most settings are in `include/config.h`
+- CPU clock adjustable via `CPU_FREQ_MHZ` to improve FPS
 
 ### Hardware Configuration
 | Module           | Part / Spec                    | Notes                   |
@@ -63,6 +66,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 | Temp Sensor 1    | **PDF00703S** (Defi)           | CH1, 0.5–4.5V           |
 | Temp Sensor 2    | **PDF00703S** (Defi)           | CH2, 0.5–4.5V           |
 | Power Supply     | 5V                             | Powered via USB         |
+| CPU Clock        | 240 MHz                        | Configurable in `include/config.h` |
 
 > 📌 Detailed wiring diagrams will be added soon.
 

--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,8 @@
 // ────────────────────── 設定 ──────────────────────
 // デバッグモードを有効にするかどうか
 constexpr bool DEBUG_MODE_ENABLED = false;
+// CPUクロック周波数設定 [MHz]
+constexpr int CPU_FREQ_MHZ = 240;
 
 // ── センサー接続可否（false にするとその項目は常に 0 表示） ──
 constexpr bool SENSOR_OIL_PRESSURE_PRESENT  = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 
 #include <M5CoreS3.h>
 #include <Wire.h>
+#include <esp32-hal-cpu.h>
 
 #include "modules/display.h"
 #include "modules/sensor.h"
@@ -21,6 +22,8 @@ void setup()
     Serial.begin(115200);
 
     M5.begin();
+    // CPUクロック設定
+    setCpuFrequencyMhz(CPU_FREQ_MHZ);
     CoreS3.begin(M5.config());
     M5.Power.begin();
     CoreS3.Ltr553.begin(&ltr553InitParams);


### PR DESCRIPTION
## Summary / 概要
- add `CPU_FREQ_MHZ` constant to configure CPU clock
- set CPU frequency in `setup()` for better frame rates
- document configuration in README in Japanese and English

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685934ed76148322be6033ee046c2665