### PR TITLE
Change temp sampling interval to 500ms / 温度取得間隔を500msに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
   - 本リポジトリでは **油圧**・**油温** を実装済み
 - 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
 - 各種設定は `include/config.h` の定数で変更可能
+- 水温・油温は500ms間隔で取得し、10サンプル平均を5秒ごとに更新
 
 ### ハードウェア構成
 | モジュール       | 型番 / 仕様                       | 備考                     |
@@ -53,6 +54,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
   - In this repository, **oil pressure** and **oil temperature** are implemented.
 - Digital + bar graph temperature display
 - Most settings are in `include/config.h`
+- Water and oil temperatures are sampled every 500 ms and averaged over 10 samples (updated every 5 seconds)
 
 ### Hardware Configuration
 | Module           | Part / Spec                    | Notes                   |

--- a/include/config.h
+++ b/include/config.h
@@ -63,7 +63,7 @@ constexpr uint8_t ADC_CH_OIL_TEMP     = 2;
 
 // サンプリング数設定
 constexpr int PRESSURE_SAMPLE_SIZE   = 5;
-constexpr int WATER_TEMP_SAMPLE_SIZE = 10;
-constexpr int OIL_TEMP_SAMPLE_SIZE   = 10;
+constexpr int WATER_TEMP_SAMPLE_SIZE = 10;  // 500ms間隔×10サンプルで約5秒平均
+constexpr int OIL_TEMP_SAMPLE_SIZE   = 10;  // 500ms間隔×10サンプルで約5秒平均
 
 #endif // CONFIG_H

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -23,7 +23,8 @@ static bool oilTempFirstSample   = true;
 constexpr uint32_t ADC_SETTLING_US = 50;
 
 // 水温・油温サンプリング間隔 [ms]
-constexpr uint32_t TEMP_SAMPLE_INTERVAL_MS = 300;
+// 500msごとに取得し、10サンプルで約5秒平均となる
+constexpr uint32_t TEMP_SAMPLE_INTERVAL_MS = 500;
 
 // ────────────────────── 変換定数 ──────────────────────
 constexpr float SUPPLY_VOLTAGE          = 5.0f;


### PR DESCRIPTION
## Summary / 概要
- update TEMP_SAMPLE_INTERVAL_MS to 500ms and comment to reflect 10-sample average
- note sample interval in README (JP/EN)
- annotate sample size in config

## Testing
- `platformio run --target clean` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9c1147048322b24286a693b10350