### PR TITLE
油温センサー有効化 / Enable oil temperature sensor

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -10,7 +10,8 @@ constexpr bool DEBUG_MODE_ENABLED = false;
 // ── センサー接続可否（false にするとその項目は常に 0 表示） ──
 constexpr bool SENSOR_OIL_PRESSURE_PRESENT  = true;
 constexpr bool SENSOR_WATER_TEMP_PRESENT    = true;
-constexpr bool SENSOR_OIL_TEMP_PRESENT      = false;
+// 油温センサーを使用するかどうか
+constexpr bool SENSOR_OIL_TEMP_PRESENT      = true;
 constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
 
 // ── 色設定 (16 bit) ──


### PR DESCRIPTION
## Summary / 概要
- 油温センサーの有効化設定を `include/config.h` で `true` に変更しました
- Added Japanese comment above the setting

## Testing / テスト
- `platformio run` を試みましたが、依存解決のためのネットワークアクセスがブロックされ、ビルドを完了できませんでした

------
https://chatgpt.com/codex/tasks/task_e_685a9b9351d08322b1903c59cf2c4f9b