### PR TITLE
5Vピン給電サポート / Support powering via 5V pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 | 圧力センサ       | **PDF00903S** (Defi)              | CH0 / 0.5 – 4.5 V        |
 | 温度センサ1      | **PDF00703S** (Defi)              | CH1 / 0.5 – 4.5 V        |
 | 温度センサ2      | **PDF00703S** (Defi)              | CH2 / 0.5 – 4.5 V        |
-| 電源             | 5V                               | CoreS3 USB経由           |
+| 電源             | 5V                               | CoreS3 USB経由 または 5Vピン           |
+
+> 💡 5Vピンは入力(給電)と外部機器への出力の両方に利用できます。`M5.Power.setExtOutput(true)`で出力を有効化した状態では、外部から同時に給電しないでください。
+> 5Vピンから給電する場合は `M5.Power.setExtOutput(false)` として出力を無効にします。
 
 > 📌 詳しい配線図は後日追加予定です。
 
@@ -64,7 +67,10 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 | Pressure Sensor  | **PDF00903S** (Defi)           | CH0, 0.5–4.5V           |
 | Temp Sensor 1    | **PDF00703S** (Defi)           | CH1, 0.5–4.5V           |
 | Temp Sensor 2    | **PDF00703S** (Defi)           | CH2, 0.5–4.5V           |
-| Power Supply     | 5V                             | Powered via USB         |
+| Power Supply     | 5V                             | Powered via USB or 5V pin         |
+
+> 💡 The 5V pin can power the CoreS3 or supply external devices. When `M5.Power.setExtOutput(true)` is active, avoid feeding power from another 5V source at the same time.
+> To run from the 5V pin, keep `M5.Power.setExtOutput(false)` so the pin won't output power.
 
 > 📌 Detailed wiring diagrams will be added soon.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,8 @@ void setup()
     M5.begin();
     CoreS3.begin(M5.config());
     M5.Power.begin();
+    // 外部からの給電を利用する場合は 5V ピン出力を無効化
+    M5.Power.setExtOutput(false);
     CoreS3.Ltr553.begin(&ltr553InitParams);
     M5.Power.begin();
 


### PR DESCRIPTION
## Summary / 概要
- READMEに5Vピンから給電する際の`setExtOutput(false)`指定を追記
- `setup()`で5Vピン出力を無効化して外部電源入力に対応

## Testing / テスト
- `platformio run` *(failed: could not install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb8a480c83228ad49aa02a2170c3