### PR TITLE
Add touch menu for runtime settings / タッチメニュー機能追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 ### 主な機能
 - 油圧・燃圧・ブースト (0–9.9 bar) 半円アナログメーター
   - 本リポジトリでは **油圧**・**油温** を実装済み
-- 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示  
+- 油温 / 水温 (–40–150 °C) デジタル数値＋バー表示
 - 各種設定は `include/config.h` の定数で変更可能
 - 水温・油温は500ms間隔で取得し、10サンプル平均を5秒ごとに更新
+- タッチメニューで各センサーとデバッグモードのON/OFFを切り替え、SDカードに保存
 
 ### ハードウェア構成
 | モジュール       | 型番 / 仕様                       | 備考                     |
@@ -58,6 +59,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 - Digital + bar graph temperature display
 - Most settings are in `include/config.h`
 - Water and oil temperatures are sampled every 500 ms and averaged over 10 samples (updated every 5 seconds)
+- Touch menu lets you toggle sensors and debug mode, saving settings to SD card
 
 ### Hardware Configuration
 | Module           | Part / Spec                    | Notes                   |

--- a/include/config.h
+++ b/include/config.h
@@ -4,15 +4,19 @@
 #include <M5CoreS3.h>
 
 // ────────────────────── 設定 ──────────────────────
-// デバッグモードを有効にするかどうか
-constexpr bool DEBUG_MODE_ENABLED = false;
-
-// ── センサー接続可否（false にするとその項目は常に 0 表示） ──
-constexpr bool SENSOR_OIL_PRESSURE_PRESENT  = true;
-constexpr bool SENSOR_WATER_TEMP_PRESENT    = true;
-// 油温センサーを使用するかどうか
-constexpr bool SENSOR_OIL_TEMP_PRESENT      = true;
+// 既定値
+constexpr bool DEFAULT_DEBUG_MODE_ENABLED            = false;
+constexpr bool DEFAULT_SENSOR_OIL_PRESSURE_ENABLED   = true;
+constexpr bool DEFAULT_SENSOR_WATER_TEMP_ENABLED     = true;
+constexpr bool DEFAULT_SENSOR_OIL_TEMP_ENABLED       = true;
+// 環境光センサーの有無（固定値）
 constexpr bool SENSOR_AMBIENT_LIGHT_PRESENT = true;
+
+// 実際の設定値（起動時にSDカードから読み込み）
+extern bool debugModeEnabled;
+extern bool oilPressureEnabled;
+extern bool waterTempEnabled;
+extern bool oilTempEnabled;
 
 // ── 色設定 (16 bit) ──
 // RGB888 から 565 形式へ変換する constexpr 関数

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include "modules/display.h"
 #include "modules/sensor.h"
 #include "modules/backlight.h"
+#include "modules/settings.h"
+#include "modules/menu.h"
 
 // ── LTR553 初期設定 ──
 Ltr5xx_Init_Basic_Para ltr553InitParams = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
@@ -54,6 +56,8 @@ void setup()
     }
     adsConverter.setDataRate(RATE_ADS1015_1600SPS);
 
+    loadSettings();
+
     if (SENSOR_AMBIENT_LIGHT_PRESENT) {
         CoreS3.Ltr553.begin(&ltr553InitParams);
         CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
@@ -75,11 +79,12 @@ void loop()
 
     acquireSensorData();
     updateGauges();
+    handleMenu();
 
     frameCounterPerSecond++;
     if (now - previousFpsTimestamp >= 1000UL) {
         currentFramesPerSecond = frameCounterPerSecond;
-        if (DEBUG_MODE_ENABLED)
+        if (debugModeEnabled)
             Serial.printf("FPS:%d\n", currentFramesPerSecond);
         frameCounterPerSecond = 0;
         previousFpsTimestamp  = now;

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -1,5 +1,6 @@
 #include "display.h"
 #include "DrawFillArcMeter.h"
+#include "settings.h"
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -116,7 +117,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
         displayCache.waterTempAvg = waterTempAvg;
     }
 
-    if (DEBUG_MODE_ENABLED) {
+    if (debugModeEnabled) {
         mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
         mainCanvas.setFont(&fonts::Font0);
         mainCanvas.setTextSize(0);
@@ -145,7 +146,7 @@ void updateGauges()
     smoothOilTemp   += 0.1f * (targetOilTemp   - smoothOilTemp);
 
     float oilTempValue = smoothOilTemp;
-    if (!SENSOR_OIL_TEMP_PRESENT) oilTempValue = 0.0f;
+    if (!oilTempEnabled) oilTempValue = 0.0f;
 
     recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
     recordedMaxWaterTemp   = std::max(recordedMaxWaterTemp, smoothWaterTemp);

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -1,0 +1,62 @@
+#include "menu.h"
+#include <M5Unified.h>
+
+static bool menuVisible = false;
+
+// ────────────────────── メニュー描画 ──────────────────────
+static void drawMenu()
+{
+    const int X = 40, Y = 40, W = 240, H = 160;
+    mainCanvas.fillRect(X, Y, W, H, COLOR_BLACK);
+    mainCanvas.drawRect(X, Y, W, H, COLOR_WHITE);
+
+    int line = Y + 20;
+    auto drawItem = [&](const char* name, bool value) {
+        mainCanvas.setCursor(X + 10, line);
+        mainCanvas.printf("%s: %s", name, value ? "ON" : "OFF");
+        line += 20;
+    };
+
+    drawItem("OIL.P", oilPressureEnabled);
+    drawItem("OIL.T", oilTempEnabled);
+    drawItem("WATER.T", waterTempEnabled);
+    drawItem("DEBUG", debugModeEnabled);
+
+    mainCanvas.setCursor(X + 10, line + 10);
+    mainCanvas.print("SAVE");
+
+    mainCanvas.pushSprite(0, 0);
+}
+
+// ────────────────────── タッチ処理 ──────────────────────
+void handleMenu()
+{
+    M5.update();
+    if (!menuVisible) {
+        if (M5.Touch.getCount()) {
+            menuVisible = true;
+            drawMenu();
+        }
+        return;
+    }
+
+    if (!M5.Touch.getCount()) return;
+    auto p = M5.Touch.getPressPoint();
+    const int X = 40, Y = 40;
+
+    int index = (p.y - (Y + 20)) / 20;
+    if (p.x < X || p.x > X + 240) return;
+
+    switch (index) {
+    case 0: oilPressureEnabled = !oilPressureEnabled; drawMenu(); break;
+    case 1: oilTempEnabled = !oilTempEnabled; drawMenu(); break;
+    case 2: waterTempEnabled = !waterTempEnabled; drawMenu(); break;
+    case 3: debugModeEnabled = !debugModeEnabled; drawMenu(); break;
+    default:
+        if (p.y > Y + 100) { // SAVE area
+            saveSettings();
+            menuVisible = false;
+        }
+        break;
+    }
+}

--- a/src/modules/menu.h
+++ b/src/modules/menu.h
@@ -1,0 +1,11 @@
+#ifndef MENU_H
+#define MENU_H
+
+#include "config.h"
+#include "settings.h"
+#include "display.h"
+
+// タッチ入力を処理してメニューを表示
+void handleMenu();
+
+#endif // MENU_H

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -77,7 +77,7 @@ void acquireSensorData()
     unsigned long now = millis();
 
     // 油圧
-    if (SENSOR_OIL_PRESSURE_PRESENT) {
+    if (oilPressureEnabled) {
         int16_t raw = readAdcWithSettling(ADC_CH_OIL_PRESSURE);  // CH1: 油圧
         oilPressureSamples[oilPressureSampleIndex] =
             convertVoltageToOilPressure(convertAdcToVoltage(raw));
@@ -89,7 +89,7 @@ void acquireSensorData()
     // 水温
     if (now - previousWaterTempSampleTime >= TEMP_SAMPLE_INTERVAL_MS) {
         float value = 0.0f;
-        if (SENSOR_WATER_TEMP_PRESENT) {
+        if (waterTempEnabled) {
             int16_t raw = readAdcWithSettling(ADC_CH_WATER_TEMP);  // CH0: 水温
             value = convertVoltageToTemp(convertAdcToVoltage(raw));
         }
@@ -109,7 +109,7 @@ void acquireSensorData()
     // 油温
     if (now - previousOilTempSampleTime >= TEMP_SAMPLE_INTERVAL_MS) {
         float value = 0.0f;
-        if (SENSOR_OIL_TEMP_PRESENT) {
+        if (oilTempEnabled) {
             int16_t raw = readAdcWithSettling(ADC_CH_OIL_TEMP);  // CH2: 油温
             value = convertVoltageToTemp(convertAdcToVoltage(raw));
         }

--- a/src/modules/settings.cpp
+++ b/src/modules/settings.cpp
@@ -1,0 +1,49 @@
+#include "settings.h"
+
+bool debugModeEnabled = DEFAULT_DEBUG_MODE_ENABLED;
+bool oilPressureEnabled = DEFAULT_SENSOR_OIL_PRESSURE_ENABLED;
+bool waterTempEnabled = DEFAULT_SENSOR_WATER_TEMP_ENABLED;
+bool oilTempEnabled = DEFAULT_SENSOR_OIL_TEMP_ENABLED;
+
+static const char* SETTINGS_FILE = "/settings.txt";
+
+// ────────────────────── 設定読み込み ──────────────────────
+void loadSettings()
+{
+    if (!SD.begin(GPIO_NUM_4, SPI, 40000000)) {
+        return; // SD初期化失敗
+    }
+    File f = SD.open(SETTINGS_FILE, FILE_READ);
+    if (!f) return;
+
+    while (f.available()) {
+        String line = f.readStringUntil('\n');
+        int eq = line.indexOf('=');
+        if (eq < 0) continue;
+        String key = line.substring(0, eq);
+        String val = line.substring(eq + 1);
+        bool flag = val.toInt() != 0;
+        if (key == "debug") debugModeEnabled = flag;
+        else if (key == "oilP") oilPressureEnabled = flag;
+        else if (key == "waterT") waterTempEnabled = flag;
+        else if (key == "oilT") oilTempEnabled = flag;
+    }
+    f.close();
+}
+
+// ────────────────────── 設定保存 ──────────────────────
+void saveSettings()
+{
+    if (!SD.begin(GPIO_NUM_4, SPI, 40000000)) {
+        return; // SD初期化失敗
+    }
+    SD.remove(SETTINGS_FILE);
+    File f = SD.open(SETTINGS_FILE, FILE_WRITE);
+    if (!f) return;
+
+    f.printf("debug=%d\n", debugModeEnabled ? 1 : 0);
+    f.printf("oilP=%d\n", oilPressureEnabled ? 1 : 0);
+    f.printf("waterT=%d\n", waterTempEnabled ? 1 : 0);
+    f.printf("oilT=%d\n", oilTempEnabled ? 1 : 0);
+    f.close();
+}

--- a/src/modules/settings.h
+++ b/src/modules/settings.h
@@ -1,0 +1,13 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <SD.h>
+#include "config.h"
+
+// 設定をSDカードから読み込む
+void loadSettings();
+
+// 設定をSDカードへ保存する
+void saveSettings();
+
+#endif // SETTINGS_H


### PR DESCRIPTION
## Summary / 概要
- add runtime-configurable sensor and debug settings loaded from SD
- implement simple touch menu to toggle oil pressure, oil temp, water temp and debug mode
- save settings to SD card
- update documentation

## Testing
- `true` (no tests present)


------
https://chatgpt.com/codex/tasks/task_e_68629ce7a2ac8322ae770a1b98f311a5