### PR TITLE
react/reduce-unused-uint32

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -48,8 +48,9 @@ constexpr int LCD_HEIGHT = 240;
 // ── ALS/輝度自動制御 ──
 enum class BrightnessMode { Day, Dusk, Night };
 
-constexpr uint32_t LUX_THRESHOLD_DAY  = 15;
-constexpr uint32_t LUX_THRESHOLD_DUSK = 10;
+// ALS の輝度判定閾値
+constexpr uint8_t LUX_THRESHOLD_DAY  = 15;
+constexpr uint8_t LUX_THRESHOLD_DUSK = 10;
 
 constexpr uint8_t  BACKLIGHT_DAY   = 255;
 constexpr uint8_t  BACKLIGHT_DUSK  = 200;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -5,17 +5,18 @@
 
 // ────────────────────── グローバル変数 ──────────────────────
 BrightnessMode currentBrightnessMode = BrightnessMode::Day;
-uint32_t luxSampleBuffer[MEDIAN_BUFFER_SIZE] = {};
+uint16_t luxSampleBuffer[MEDIAN_BUFFER_SIZE] = {};
 int luxSampleIndex = 0;
 
 
 // ────────────────────── 輝度測定 ──────────────────────
-static uint32_t measureLuxWithoutBacklight()
+// バックライトを消して輝度を測定
+static uint16_t measureLuxWithoutBacklight()
 {
     uint8_t prevB = display.getBrightness();
     display.setBrightness(0);
     delayMicroseconds(500);
-    uint32_t lux = CoreS3.Ltr553.getAlsValue();
+    uint16_t lux = CoreS3.Ltr553.getAlsValue();
     display.setBrightness(prevB);
     return lux;
 }
@@ -31,15 +32,15 @@ void updateBacklightLevel()
         return;
     }
 
-    uint32_t lux = measureLuxWithoutBacklight();
+    uint16_t lux = measureLuxWithoutBacklight();
 
     luxSampleBuffer[luxSampleIndex] = lux;
     luxSampleIndex = (luxSampleIndex + 1) % MEDIAN_BUFFER_SIZE;
 
-    uint32_t sorted[MEDIAN_BUFFER_SIZE];
+    uint16_t sorted[MEDIAN_BUFFER_SIZE];
     memcpy(sorted, luxSampleBuffer, sizeof(sorted));
     std::nth_element(sorted, sorted + MEDIAN_BUFFER_SIZE / 2, sorted + MEDIAN_BUFFER_SIZE);
-    uint32_t medianLux = sorted[MEDIAN_BUFFER_SIZE / 2];
+    uint16_t medianLux = sorted[MEDIAN_BUFFER_SIZE / 2];
 
     BrightnessMode newMode =
         (medianLux >= LUX_THRESHOLD_DAY)  ? BrightnessMode::Day  :

--- a/src/modules/backlight.h
+++ b/src/modules/backlight.h
@@ -5,7 +5,8 @@
 
 extern BrightnessMode currentBrightnessMode;
 
-constexpr uint32_t ALS_MEASUREMENT_INTERVAL_MS = 8000;  // ALS 測定間隔 [ms]
+// ALS 測定間隔 [ms]
+constexpr uint16_t ALS_MEASUREMENT_INTERVAL_MS = 8000;
 
 void updateBacklightLevel();
 

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -39,7 +39,7 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
 
     if (oilTemp >= MIN_TEMP) {
         int barWidth = static_cast<int>(W * (oilTemp - MIN_TEMP) / RANGE);
-        uint32_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
+        uint16_t barColor = (oilTemp >= ALERT_TEMP) ? COLOR_RED : COLOR_WHITE;
         canvas.fillRect(X, Y, barWidth, H, barColor);
     }
 

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -19,12 +19,12 @@ static int oilTemperatureSampleIndex = 0;
 static bool waterTempFirstSample = true;
 static bool oilTempFirstSample   = true;
 
-// セトリング用待ち時間 [us]
-constexpr uint32_t ADC_SETTLING_US = 50;
+// ADC セトリング待ち時間 [us]
+constexpr uint16_t ADC_SETTLING_US = 50;
 
-// 水温・油温サンプリング間隔 [ms]
+// 温度サンプリング間隔 [ms]
 // 500msごとに取得し、10サンプルで約5秒平均となる
-constexpr uint32_t TEMP_SAMPLE_INTERVAL_MS = 500;
+constexpr uint16_t TEMP_SAMPLE_INTERVAL_MS = 500;
 
 // ────────────────────── 変換定数 ──────────────────────
 constexpr float SUPPLY_VOLTAGE          = 5.0f;


### PR DESCRIPTION
## Summary / 概要
- replace unnecessary uint32_t types with uint16_t or uint8_t
- update comments accordingly

## Testing / テスト
- `platformio run -e m5stack-cores3` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de92458fc832295eddf63317d1273