### PR TITLE
Add settings menu / 設定メニュー追加

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -1,0 +1,18 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <Arduino.h>
+
+struct AppSettings {
+    bool showOilPressure;
+    bool showWaterTemp;
+    bool showOilTemp;
+    bool debugMode;
+};
+
+extern AppSettings settings;
+
+void loadSettings();
+void saveSettings();
+
+#endif // SETTINGS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,7 @@ void openSettingsMenu()
             delay(10);
             continue;
         }
-        auto p = M5.Touch.getPressPoint();
+        auto p = M5.Touch.getTouchPointRaw();
         if (p.y < 50) {
             settings.showOilPressure = !settings.showOilPressure;
         } else if (p.y < 90) {

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -1,5 +1,6 @@
 #include "display.h"
 #include "DrawFillArcMeter.h"
+#include "settings.h"
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -116,7 +117,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
         displayCache.waterTempAvg = waterTempAvg;
     }
 
-    if (DEBUG_MODE_ENABLED) {
+    if (settings.debugMode) {
         mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
         mainCanvas.setFont(&fonts::Font0);
         mainCanvas.setTextSize(0);
@@ -145,7 +146,7 @@ void updateGauges()
     smoothOilTemp   += 0.1f * (targetOilTemp   - smoothOilTemp);
 
     float oilTempValue = smoothOilTemp;
-    if (!SENSOR_OIL_TEMP_PRESENT) oilTempValue = 0.0f;
+    if (!settings.showOilTemp) oilTempValue = 0.0f;
 
     recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
     recordedMaxWaterTemp   = std::max(recordedMaxWaterTemp, smoothWaterTemp);

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -1,4 +1,5 @@
 #include "sensor.h"
+#include "settings.h"
 #include <algorithm>
 #include <cmath>
 #include <numeric>
@@ -77,7 +78,7 @@ void acquireSensorData()
     unsigned long now = millis();
 
     // 油圧
-    if (SENSOR_OIL_PRESSURE_PRESENT) {
+    if (settings.showOilPressure) {
         int16_t raw = readAdcWithSettling(ADC_CH_OIL_PRESSURE);  // CH1: 油圧
         oilPressureSamples[oilPressureSampleIndex] =
             convertVoltageToOilPressure(convertAdcToVoltage(raw));
@@ -89,7 +90,7 @@ void acquireSensorData()
     // 水温
     if (now - previousWaterTempSampleTime >= TEMP_SAMPLE_INTERVAL_MS) {
         float value = 0.0f;
-        if (SENSOR_WATER_TEMP_PRESENT) {
+        if (settings.showWaterTemp) {
             int16_t raw = readAdcWithSettling(ADC_CH_WATER_TEMP);  // CH0: 水温
             value = convertVoltageToTemp(convertAdcToVoltage(raw));
         }
@@ -109,7 +110,7 @@ void acquireSensorData()
     // 油温
     if (now - previousOilTempSampleTime >= TEMP_SAMPLE_INTERVAL_MS) {
         float value = 0.0f;
-        if (SENSOR_OIL_TEMP_PRESENT) {
+        if (settings.showOilTemp) {
             int16_t raw = readAdcWithSettling(ADC_CH_OIL_TEMP);  // CH2: 油温
             value = convertVoltageToTemp(convertAdcToVoltage(raw));
         }

--- a/src/modules/settings.cpp
+++ b/src/modules/settings.cpp
@@ -1,0 +1,43 @@
+#include "settings.h"
+#include "config.h"
+#include <M5CoreS3.h>
+#include <SD.h>
+
+// ────────────────────── デフォルト設定 ──────────────────────
+AppSettings settings = {SENSOR_OIL_PRESSURE_PRESENT,
+                        SENSOR_WATER_TEMP_PRESENT,
+                        SENSOR_OIL_TEMP_PRESENT,
+                        DEBUG_MODE_ENABLED};
+
+static const char* SETTINGS_FILE = "/settings.txt";
+
+// ────────────────────── 読み込み ──────────────────────
+void loadSettings()
+{
+    if (!SD.begin()) return;
+    File f = SD.open(SETTINGS_FILE, FILE_READ);
+    if (!f) return;
+    String line = f.readStringUntil('\n');
+    if (line.length() > 0) settings.showOilPressure = line.toInt();
+    line = f.readStringUntil('\n');
+    if (line.length() > 0) settings.showWaterTemp = line.toInt();
+    line = f.readStringUntil('\n');
+    if (line.length() > 0) settings.showOilTemp = line.toInt();
+    line = f.readStringUntil('\n');
+    if (line.length() > 0) settings.debugMode = line.toInt();
+    f.close();
+}
+
+// ────────────────────── 保存 ──────────────────────
+void saveSettings()
+{
+    if (!SD.begin()) return;
+    File f = SD.open(SETTINGS_FILE, FILE_WRITE | O_TRUNC);
+    if (!f) return;
+    f.printf("%d\n%d\n%d\n%d\n",
+             settings.showOilPressure,
+             settings.showWaterTemp,
+             settings.showOilTemp,
+             settings.debugMode);
+    f.close();
+}


### PR DESCRIPTION
## Summary / 概要
- add runtime `settings` module to load/save options on SD
- support menu via touch to toggle oil pressure, water temp, oil temp, and debug mode
- store changes to `/settings.txt`

## Testing
- `platformio run` *(failed: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686dea5a6f848322896d4e308fc7eded