### PR TITLE
Enable DMA init / DMA初期化の追加

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,12 +30,18 @@ void setup()
     M5.Power.setExtOutput(false);
 
     display.init();
+    // DMA を初期化
+    display.initDMA();
     display.setRotation(3);
     display.setColorDepth(16);
     display.setBrightness(BACKLIGHT_DAY);
 
     mainCanvas.setColorDepth(16);
     mainCanvas.setTextSize(1);
+    // スプライトを PSRAM ではなく DMA メモリに確保
+    mainCanvas.setPsram(false);
+    // スプライト用の DMA を初期化
+    mainCanvas.initDMA();
     mainCanvas.createSprite(LCD_WIDTH, LCD_HEIGHT);
 
     M5.Lcd.clear();


### PR DESCRIPTION
## Summary
- initialize DMA for the display and sprite
- ensure sprite memory is allocated for DMA transfers

## Testing
- `clang-tidy src/main.cpp -- -Iinclude` *(fails: 'M5CoreS3.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686947c962948322aecdb1b1d80024e8