### PR TITLE
Add touch menu for gauge display and debug / タッチメニューによる表示切替

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "modules/display.h"
 #include "modules/sensor.h"
 #include "modules/backlight.h"
+#include "menu/menu.h"
 
 // ── LTR553 初期設定 ──
 Ltr5xx_Init_Basic_Para ltr553InitParams = LTR5XX_BASE_PARA_CONFIG_DEFAULT;
@@ -47,6 +48,9 @@ void setup()
     M5.Lcd.clear();
     M5.Lcd.fillScreen(COLOR_BLACK);
 
+    // SD カードから設定を読み込み
+    loadConfig();
+
     M5.Speaker.begin();
     M5.Imu.begin();
     btStop();
@@ -74,6 +78,11 @@ void loop()
     static unsigned long previousAlsSampleTime = 0;
     unsigned long now = millis();
 
+    M5.update();
+    if (M5.Touch.wasPressed()) {
+        showMenu();
+    }
+
     if (now - previousAlsSampleTime >= ALS_MEASUREMENT_INTERVAL_MS) {
         updateBacklightLevel();
         previousAlsSampleTime = now;
@@ -85,7 +94,7 @@ void loop()
     frameCounterPerSecond++;
     if (now - previousFpsTimestamp >= 1000UL) {
         currentFramesPerSecond = frameCounterPerSecond;
-        if (DEBUG_MODE_ENABLED)
+        if (appConfig.debugMode)
             Serial.printf("FPS:%d\n", currentFramesPerSecond);
         frameCounterPerSecond = 0;
         previousFpsTimestamp  = now;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,7 +79,7 @@ void loop()
     unsigned long now = millis();
 
     M5.update();
-    if (M5.Touch.wasPressed()) {
+    if (M5.Touch.getDetail().wasPressed()) {
         showMenu();
     }
 

--- a/src/menu/menu.cpp
+++ b/src/menu/menu.cpp
@@ -1,4 +1,5 @@
 #include "menu.h"
+#include "../modules/display.h"
 
 // グローバル設定変数
 AppConfig appConfig = {true, true, true, DEBUG_MODE_ENABLED};
@@ -69,8 +70,9 @@ void showMenu()
     drawMenu();
     while (true) {
         M5.update();
-        if (M5.Touch.isPressed()) {
-            auto t = M5.Touch.getPressPoint();
+        auto detail = M5.Touch.getDetail();
+        if (detail.wasPressed()) {
+            auto t = detail;
             if (t.y < 40) {
                 appConfig.showOilPressure = !appConfig.showOilPressure;
                 drawMenu();
@@ -87,7 +89,7 @@ void showMenu()
                 saveConfig();
                 break;
             }
-            while (M5.Touch.isPressed()) M5.update();
+            while (M5.Touch.getDetail().isPressed()) M5.update();
         }
     }
     display.fillScreen(COLOR_BLACK);

--- a/src/menu/menu.cpp
+++ b/src/menu/menu.cpp
@@ -1,0 +1,95 @@
+#include "menu.h"
+
+// グローバル設定変数
+AppConfig appConfig = {true, true, true, DEBUG_MODE_ENABLED};
+
+// 設定ファイルのパス
+static const char* CONFIG_PATH = "/config.txt";
+
+// ────────────────────── 設定読み込み ──────────────────────
+void loadConfig()
+{
+    if (!SD.begin(GPIO_NUM_4, SPI, 25000000)) {
+        Serial.println("SD init failed");
+        return;
+    }
+    File f = SD.open(CONFIG_PATH, FILE_READ);
+    if (!f) return;
+    while (f.available()) {
+        String line = f.readStringUntil('\n');
+        if (line.startsWith("oil_pressure="))
+            appConfig.showOilPressure = line.substring(13).toInt();
+        else if (line.startsWith("water_temp="))
+            appConfig.showWaterTemp = line.substring(11).toInt();
+        else if (line.startsWith("oil_temp="))
+            appConfig.showOilTemp = line.substring(9).toInt();
+        else if (line.startsWith("debug="))
+            appConfig.debugMode = line.substring(6).toInt();
+    }
+    f.close();
+}
+
+// ────────────────────── 設定保存 ──────────────────────
+void saveConfig()
+{
+    if (!SD.begin(GPIO_NUM_4, SPI, 25000000)) {
+        Serial.println("SD init failed");
+        return;
+    }
+    File f = SD.open(CONFIG_PATH, FILE_WRITE);
+    if (!f) return;
+    f.printf("oil_pressure=%d\n", appConfig.showOilPressure);
+    f.printf("water_temp=%d\n", appConfig.showWaterTemp);
+    f.printf("oil_temp=%d\n", appConfig.showOilTemp);
+    f.printf("debug=%d\n", appConfig.debugMode);
+    f.close();
+}
+
+// ────────────────────── メニュー描画 ──────────────────────
+static void drawMenu()
+{
+    display.fillScreen(COLOR_BLACK);
+    display.setTextFont(1);
+    display.setTextSize(2);
+    display.setCursor(10, 20);
+    display.printf("油圧表示: %s", appConfig.showOilPressure ? "ON" : "OFF");
+    display.setCursor(10, 50);
+    display.printf("水温表示: %s", appConfig.showWaterTemp ? "ON" : "OFF");
+    display.setCursor(10, 80);
+    display.printf("油温表示: %s", appConfig.showOilTemp ? "ON" : "OFF");
+    display.setCursor(10, 110);
+    display.printf("デバッグ: %s", appConfig.debugMode ? "ON" : "OFF");
+    display.setCursor(10, 160);
+    display.print("SAVE をタップ");
+}
+
+// ────────────────────── メニュー表示 ──────────────────────
+void showMenu()
+{
+    drawMenu();
+    while (true) {
+        M5.update();
+        if (M5.Touch.isPressed()) {
+            auto t = M5.Touch.getPressPoint();
+            if (t.y < 40) {
+                appConfig.showOilPressure = !appConfig.showOilPressure;
+                drawMenu();
+            } else if (t.y < 70) {
+                appConfig.showWaterTemp = !appConfig.showWaterTemp;
+                drawMenu();
+            } else if (t.y < 100) {
+                appConfig.showOilTemp = !appConfig.showOilTemp;
+                drawMenu();
+            } else if (t.y < 130) {
+                appConfig.debugMode = !appConfig.debugMode;
+                drawMenu();
+            } else {
+                saveConfig();
+                break;
+            }
+            while (M5.Touch.isPressed()) M5.update();
+        }
+    }
+    display.fillScreen(COLOR_BLACK);
+}
+

--- a/src/menu/menu.h
+++ b/src/menu/menu.h
@@ -1,0 +1,21 @@
+#ifndef MENU_H
+#define MENU_H
+
+#include <M5Unified.h>
+#include <SD.h>
+#include "config.h"
+
+struct AppConfig {
+    bool showOilPressure;
+    bool showWaterTemp;
+    bool showOilTemp;
+    bool debugMode;
+};
+
+extern AppConfig appConfig;
+
+void loadConfig();
+void saveConfig();
+void showMenu();
+
+#endif // MENU_H

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -1,5 +1,6 @@
 #include "display.h"
 #include "DrawFillArcMeter.h"
+#include "../menu/menu.h"
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -82,15 +83,17 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
 
     mainCanvas.setTextColor(COLOR_WHITE);
 
-    if (oilChanged) {
+    if (oilChanged && appConfig.showOilTemp) {
         mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
         if (oilTemp > maxOilTemp) maxOilTemp = oilTemp;
         drawOilTemperatureTopBar(mainCanvas, oilTemp, maxOilTemp);
         displayCache.oilTemp    = oilTemp;
         displayCache.maxOilTemp = maxOilTemp;
+    } else if (!appConfig.showOilTemp) {
+        mainCanvas.fillRect(0, TOPBAR_Y, LCD_WIDTH, TOPBAR_H, COLOR_BLACK);
     }
 
-    if (pressureChanged || !pressureGaugeInitialized) {
+    if ((pressureChanged || !pressureGaugeInitialized) && appConfig.showOilPressure) {
         if (!pressureGaugeInitialized) {
             mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
         }
@@ -101,9 +104,12 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
                          !pressureGaugeInitialized);
         pressureGaugeInitialized = true;
         displayCache.pressureAvg = pressureAvg;
+    } else if (!appConfig.showOilPressure && pressureGaugeInitialized) {
+        mainCanvas.fillRect(0, 60, 160, GAUGE_H, COLOR_BLACK);
+        pressureGaugeInitialized = false;
     }
 
-    if (waterChanged || !waterGaugeInitialized) {
+    if ((waterChanged || !waterGaugeInitialized) && appConfig.showWaterTemp) {
         if (!waterGaugeInitialized) {
             mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
         }
@@ -114,9 +120,12 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
                          5.0f, WATER_TEMP_METER_MIN);
         waterGaugeInitialized = true;
         displayCache.waterTempAvg = waterTempAvg;
+    } else if (!appConfig.showWaterTemp && waterGaugeInitialized) {
+        mainCanvas.fillRect(160, 60, 160, GAUGE_H, COLOR_BLACK);
+        waterGaugeInitialized = false;
     }
 
-    if (DEBUG_MODE_ENABLED) {
+    if (appConfig.debugMode) {
         mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
         mainCanvas.setFont(&fonts::Font0);
         mainCanvas.setTextSize(0);


### PR DESCRIPTION
## Summary / 概要
- add configuration menu accessible via touch
- allow toggling oil pressure, water temp, oil temp gauges and debug mode
- save settings to SD card
- display gauges according to settings

## Testing / テスト
- `pio run -e m5stack-cores3` *(failed: missing packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686e42d0dc408322a792f613fdd31fdc