### PR TITLE
snprintf を使用して安全性向上 / Improve safety with snprintf

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <cstdio>
 
 // ────────────────────── グローバル変数 ──────────────────────
 M5GFX display;
@@ -60,7 +61,9 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
     canvas.setCursor(X, Y + H + 4);
     canvas.printf("OIL.T / Celsius,  MAX:%03d", maxOilTemp);
     char tempStr[6];
-    sprintf(tempStr, "%d", static_cast<int>(oilTemp));
+    // snprintf でバッファサイズを指定し、
+    // 安全に文字列化する
+    snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
     canvas.setFont(&FreeSansBold24pt7b);
     canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
 }


### PR DESCRIPTION
## 日本語
- `src/modules/display.cpp` で `sprintf` を `snprintf` に変更し、バッファオーバーランを防止
- それに伴い `<cstdio>` を追加
- コメントを日本語で追加し、処理の安全性向上を説明

## English
- Replaced `sprintf` with `snprintf` in `src/modules/display.cpp` to avoid buffer overflow
- Added `<cstdio>` include accordingly
- Added Japanese comments describing the safety improvement

------
https://chatgpt.com/codex/tasks/task_e_686e8da773cc832299467b58033a9ce8