### PR TITLE
Add DCE display when temperature >=199 / 温度が199度以上でDCE表示

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -183,7 +183,11 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
 
   // 値を右下に表示
   char valueText[10];
-  if (useDecimal)
+  if (value >= 199.0f) {
+    // 199℃以上は "DCE" を表示
+    snprintf(valueText, sizeof(valueText), "DCE");
+  }
+  else if (useDecimal)
   {
     snprintf(valueText, sizeof(valueText), "%.1f", value);
   }

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -67,7 +67,12 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
     char tempStr[6];
     // snprintf でバッファサイズを指定し、
     // 安全に文字列化する
-    snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
+    // 199℃以上は異常値として "DCE" を表示
+    if (oilTemp >= 199.0f) {
+        snprintf(tempStr, sizeof(tempStr), "DCE");
+    } else {
+        snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
+    }
     canvas.setFont(&FreeSansBold24pt7b);
     canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
 }


### PR DESCRIPTION
## Summary / 概要
- show `DCE` when temperatures reach 199°C or more
- display `DCE` in oil temperature bar and gauge numeric area

## Testing
- `platformio run` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68727255aac483228878fbb899be0f1c