### PR TITLE
FPS表示を改行してラベル重複を回避 / Avoid overlap in FPS label

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -134,8 +134,9 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
         mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
         mainCanvas.setFont(&fonts::Font0);
         mainCanvas.setTextSize(0);
-        mainCanvas.setCursor(5, LCD_HEIGHT - 12);
-        mainCanvas.printf("FPS:%d", currentFramesPerSecond);
+        // FPS表示がラベルと重ならないように改行して描画
+        mainCanvas.setCursor(5, LCD_HEIGHT - 16);
+        mainCanvas.printf("FPS:\n%d", currentFramesPerSecond);
     }
 
     mainCanvas.pushSprite(0, 0);


### PR DESCRIPTION
## 日本語
FPSラベルが他の表示と重ならないよう、画面上のデバッグ表示を二行に変更しました。

## English
Updated on-screen FPS debug text to use two lines so that the label no longer overlaps with other elements.

------
https://chatgpt.com/codex/tasks/task_e_687279cdf35083228a59c9b351bd60a1