### PR TITLE
FPS表示を改行してラベル重複を回避 / Avoid overlap in FPS label

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -131,12 +131,23 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     }
 
     if (DEBUG_MODE_ENABLED) {
-        mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
+        // FPS ラベルを一度だけ描画し、数値部分だけを更新する
+        static bool fpsLabelDrawn = false;
         mainCanvas.setFont(&fonts::Font0);
         mainCanvas.setTextSize(0);
-        // FPS表示がラベルと重ならないように改行して描画
-        mainCanvas.setCursor(5, LCD_HEIGHT - 16);
-        mainCanvas.printf("FPS:\n%d", currentFramesPerSecond);
+
+        if (!fpsLabelDrawn) {
+            // 表示領域を初期化してラベルを描画
+            mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
+            mainCanvas.setCursor(5, LCD_HEIGHT - 16);
+            mainCanvas.println("FPS:");
+            fpsLabelDrawn = true;
+        }
+
+        // 数値表示部のみ塗り直して更新
+        mainCanvas.fillRect(5, LCD_HEIGHT - 8, 30, 8, COLOR_BLACK);
+        mainCanvas.setCursor(5, LCD_HEIGHT - 8);
+        mainCanvas.printf("%d", currentFramesPerSecond);
     }
 
     mainCanvas.pushSprite(0, 0);

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -134,8 +134,9 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
         mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
         mainCanvas.setFont(&fonts::Font0);
         mainCanvas.setTextSize(0);
-        mainCanvas.setCursor(5, LCD_HEIGHT - 12);
-        mainCanvas.printf("FPS:%d", currentFramesPerSecond);
+        // FPS表示がラベルと重ならないように改行して描画
+        mainCanvas.setCursor(5, LCD_HEIGHT - 16);
+        mainCanvas.printf("FPS:\n%d", currentFramesPerSecond);
     }
 
     mainCanvas.pushSprite(0, 0);

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -1,4 +1,5 @@
 #include "display.h"
+#include "fps_display.h"
 #include "DrawFillArcMeter.h"
 #include <algorithm>
 #include <cmath>
@@ -131,23 +132,7 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     }
 
     if (DEBUG_MODE_ENABLED) {
-        // FPS ラベルを一度だけ描画し、数値部分だけを更新する
-        static bool fpsLabelDrawn = false;
-        mainCanvas.setFont(&fonts::Font0);
-        mainCanvas.setTextSize(0);
-
-        if (!fpsLabelDrawn) {
-            // 表示領域を初期化してラベルを描画
-            mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
-            mainCanvas.setCursor(5, LCD_HEIGHT - 16);
-            mainCanvas.println("FPS:");
-            fpsLabelDrawn = true;
-        }
-
-        // 数値表示部のみ塗り直して更新
-        mainCanvas.fillRect(5, LCD_HEIGHT - 8, 30, 8, COLOR_BLACK);
-        mainCanvas.setCursor(5, LCD_HEIGHT - 8);
-        mainCanvas.printf("%d", currentFramesPerSecond);
+        drawFpsOverlay();
     }
 
     mainCanvas.pushSprite(0, 0);

--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -1,0 +1,25 @@
+#include "fps_display.h"
+#include "display.h"
+
+// FPSラベルが描画済みかどうかを保持
+static bool fpsLabelDrawn = false;
+
+// ────────────────────── FPS表示 ──────────────────────
+void drawFpsOverlay()
+{
+    mainCanvas.setFont(&fonts::Font0);
+    mainCanvas.setTextSize(0);
+
+    if (!fpsLabelDrawn) {
+        // 表示領域を初期化してラベルを描画
+        mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
+        mainCanvas.setCursor(5, LCD_HEIGHT - 16);
+        mainCanvas.println("FPS:");
+        fpsLabelDrawn = true;
+    }
+
+    // 数値表示部のみ塗り直して更新
+    mainCanvas.fillRect(5, LCD_HEIGHT - 8, 30, 8, COLOR_BLACK);
+    mainCanvas.setCursor(5, LCD_HEIGHT - 8);
+    mainCanvas.printf("%d", currentFramesPerSecond);
+}

--- a/src/modules/fps_display.h
+++ b/src/modules/fps_display.h
@@ -1,0 +1,6 @@
+#ifndef FPS_DISPLAY_H
+#define FPS_DISPLAY_H
+
+void drawFpsOverlay();
+
+#endif // FPS_DISPLAY_H


### PR DESCRIPTION
## 日本語
FPSラベルが他の表示と重ならないよう、画面上のデバッグ表示を二行に変更しました。

## English
Updated on-screen FPS debug text to use two lines so that the label no longer overlaps with other elements.

------
https://chatgpt.com/codex/tasks/task_e_687279cdf35083228a59c9b351bd60a1