### PR TITLE
Add Mermaid wiring diagram / Mermaid 配線図の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 > 💡 5Vピンは入力(給電)と外部機器への出力の両方に利用できます。`M5.Power.setExtOutput(true)`で出力を有効化した状態では、外部から同時に給電しないでください。
 > 5Vピンから給電する場合は `M5.Power.setExtOutput(false)` として出力を無効にします。
 
-> 📌 詳しい配線図は後日追加予定です。
+> 配線例は[こちら](docs/wiring.md)を参照してください。
 
 ### ビルド方法
 1. [PlatformIO](https://platformio.org/) をインストール (VS Code 推奨)
@@ -78,7 +78,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 > 💡 The 5V pin can power the CoreS3 or supply external devices. When `M5.Power.setExtOutput(true)` is active, avoid feeding power from another 5V source at the same time.
 > To run from the 5V pin, keep `M5.Power.setExtOutput(false)` so the pin won't output power.
 
-> 📌 Detailed wiring diagrams will be added soon.
+> See [wiring example](docs/wiring.md).
 
 ### Build Instructions
 1. Install [PlatformIO](https://platformio.org/) (VS Code recommended)

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -1,0 +1,67 @@
+# 配線例 / Wiring Example
+
+## Mermaid 配線図 / Mermaid Wiring Diagram
+
+```mermaid
+graph LR
+    subgraph Core
+        CoreS3[M5Stack CoreS3]
+    end
+    subgraph ADC
+        ADS1015[ADS1015]
+    end
+    subgraph Sensors
+        OilTemp[PDF00703S\n(油温)]
+        WaterTemp[PDF00703S\n(水温)]
+        OilPress[PDF00903S\n(油圧)]
+    end
+    OilTemp -- A0 --> ADS1015
+    WaterTemp -- A1 --> ADS1015
+    OilPress -- A2 --> ADS1015
+    ADS1015 -- GPIO9 SDA --> CoreS3
+    ADS1015 -- GPIO8 SCL --> CoreS3
+    CoreS3 ..> ADS1015 : 5V / GND
+    CoreS3 ..> Sensors : 5V / GND
+```
+
+## M5Stack CoreS3 と ADS1015
+
+| CoreS3 ピン | ADS1015 ピン | 説明 |
+|-------------|--------------|------|
+| 5V          | VDD          | 電源 (5V)
+| GND         | GND          | 共通 GND
+| GPIO9       | SDA          | I²C データ (Wire.begin(9, 8))
+| GPIO8       | SCL          | I²C クロック
+
+## ADS1015 とセンサー
+
+| ADS1015 チャンネル | 接続センサー | 備考 |
+|--------------------|--------------|------|
+| A0                 | PDF00703S (油温) | 0.5–4.5 V アナログ出力
+| A1                 | PDF00703S (水温) | 0.5–4.5 V アナログ出力
+| A2                 | PDF00903S (油圧) | 0.5–4.5 V アナログ出力
+
+各センサーの電源は 5V を使用し、GND を共通にしてください。
+
+---
+
+## Wiring Example (English)
+
+### M5Stack CoreS3 to ADS1015
+
+| CoreS3 Pin | ADS1015 Pin | Note |
+|------------|-------------|------|
+| 5V         | VDD         | Power (5V)
+| GND        | GND         | Common ground
+| GPIO9      | SDA         | I²C data (Wire.begin(9, 8))
+| GPIO8      | SCL         | I²C clock
+
+### ADS1015 to Sensors
+
+| ADS1015 Channel | Sensor | Note |
+|-----------------|--------|------|
+| A0 | PDF00703S (Oil Temp) | 0.5–4.5 V analog output
+| A1 | PDF00703S (Water Temp) | 0.5–4.5 V analog output
+| A2 | PDF00903S (Oil Pressure) | 0.5–4.5 V analog output
+
+Supply all sensors with 5V and share the ground line.


### PR DESCRIPTION
## Summary / 概要
- add mermaid-based wiring diagram in `docs/wiring.md`
- keep README link to wiring guide

## Testing
- `platformio run` *(failed: registry domains blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68727ac080208322a32d3434621eb726