### PR TITLE
199℃以上をDE表示に変更 / Show DE for values >=199°C

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -39,6 +39,12 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   const uint16_t TEXT_COLOR = COLOR_WHITE;        // テキストの色
   const uint16_t MAX_VALUE_COLOR = COLOR_RED;     // 未使用だが互換のため残置
 
+  bool valueError = value >= 199.0f;
+  if (valueError) {
+    // 異常値の場合は 0 として扱う
+    value = 0.0f;
+  }
+
   // 値を範囲内に収める
   float clampedValue = value;
   if (clampedValue < minValue)
@@ -183,9 +189,9 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
 
   // 値を右下に表示
   char valueText[10];
-  if (value >= 199.0f) {
-    // 199℃以上は "DCE" を表示
-    snprintf(valueText, sizeof(valueText), "DCE");
+  if (valueError) {
+    // 199℃以上は "DE" を表示
+    snprintf(valueText, sizeof(valueText), "DE");
   }
   else if (useDecimal)
   {


### PR DESCRIPTION
## Summary / 概要
- treat sensor readings >=199°C as 0
- display "DE" instead of "DCE" when sensor value is out of range

## Testing / テスト
- `pio run -e m5stack-cores3` *(failed: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_68727966eb8083229d7da48f65ed9125