### PR TITLE
Add sensor conversion unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
         run: pip install platformio
       - name: Build
         run: pio run -e m5stack-cores3
+      - name: Run unit tests
+        run: pio test -e test

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,3 +23,4 @@ upload_port = COM11
 [env:test]
 platform = native
 build_flags = -Isrc -Iinclude -Itest/stubs
+build_src_filter = +<src/> +<test/stubs/Wire.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,7 @@ lib_deps =
 lib_ldf_mode = deep
 monitor_speed = 115200
 upload_port = COM11
+
+[env:test]
+platform = native
+build_flags = -Isrc -Iinclude -Itest/stubs

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -3,6 +3,7 @@
 
 #include <Adafruit_ADS1X15.h>
 #include <stdint.h>
+#include <cstddef>
 #include "config.h"
 
 extern Adafruit_ADS1015 adsConverter;

--- a/test/stubs/Adafruit_ADS1X15.h
+++ b/test/stubs/Adafruit_ADS1X15.h
@@ -1,0 +1,9 @@
+#ifndef ADAFRUIT_ADS1X15_H
+#define ADAFRUIT_ADS1X15_H
+#include <stdint.h>
+// テスト用の簡単なスタブクラス
+class Adafruit_ADS1015 {
+public:
+    int16_t readADC_SingleEnded(uint8_t) { return 0; }
+};
+#endif

--- a/test/stubs/Arduino.h
+++ b/test/stubs/Arduino.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_H
+#define ARDUINO_H
+#include <stdint.h>
+// 最小限の Arduino 互換API
+static inline void delayMicroseconds(unsigned int) {}
+static inline unsigned long millis() { return 0; }
+#endif

--- a/test/stubs/M5CoreS3.h
+++ b/test/stubs/M5CoreS3.h
@@ -1,4 +1,5 @@
 #ifndef M5CORES3_H
 #define M5CORES3_H
 // M5Stack 用のダミーヘッダー
+#include "Arduino.h"
 #endif

--- a/test/stubs/M5CoreS3.h
+++ b/test/stubs/M5CoreS3.h
@@ -1,0 +1,4 @@
+#ifndef M5CORES3_H
+#define M5CORES3_H
+// M5Stack 用のダミーヘッダー
+#endif

--- a/test/stubs/Wire.cpp
+++ b/test/stubs/Wire.cpp
@@ -1,0 +1,3 @@
+#include "Wire.h"
+// スタブ用のグローバルインスタンス
+TwoWire Wire;

--- a/test/stubs/Wire.h
+++ b/test/stubs/Wire.h
@@ -1,0 +1,6 @@
+#ifndef WIRE_H
+#define WIRE_H
+// I2C 通信用のスタブクラス
+class TwoWire {};
+extern TwoWire Wire;
+#endif

--- a/test/test_sensor.cpp
+++ b/test/test_sensor.cpp
@@ -30,17 +30,13 @@ void test_convertVoltageToTemp_invalid_high() {
     TEST_ASSERT_EQUAL_FLOAT(200.0f, convertVoltageToTemp(5.0f));
 }
 
-void setup() {
-    // テスト初期化
+int main(int argc, char **argv) {
+    // Unity のテストランナー
     UNITY_BEGIN();
     RUN_TEST(test_convertAdcToVoltage_nominal);
     RUN_TEST(test_convertAdcToVoltage_negative);
     RUN_TEST(test_convertVoltageToTemp_normal);
     RUN_TEST(test_convertVoltageToTemp_invalid_low);
     RUN_TEST(test_convertVoltageToTemp_invalid_high);
-    UNITY_END();
-}
-
-void loop() {
-    // ループ処理は使用しない
+    return UNITY_END();
 }

--- a/test/test_sensor.cpp
+++ b/test/test_sensor.cpp
@@ -1,0 +1,46 @@
+#include <unity.h>
+#include "modules/sensor.h"
+// センサ変換関数の単体テスト
+
+void test_convertAdcToVoltage_nominal() {
+    // 正常範囲の ADC 値
+    float result = convertAdcToVoltage(1024);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 3.07f, result);
+}
+
+void test_convertAdcToVoltage_negative() {
+    // 負の ADC 値でも計算可能か確認
+    float result = convertAdcToVoltage(-1024);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -3.07f, result);
+}
+
+void test_convertVoltageToTemp_normal() {
+    // 2.5V は約 25℃
+    float temp = convertVoltageToTemp(2.5f);
+    TEST_ASSERT_FLOAT_WITHIN(1.0f, 25.0f, temp);
+}
+
+void test_convertVoltageToTemp_invalid_low() {
+    // 0V 以下は異常値として 200℃ を返す
+    TEST_ASSERT_EQUAL_FLOAT(200.0f, convertVoltageToTemp(0.0f));
+}
+
+void test_convertVoltageToTemp_invalid_high() {
+    // 5V 以上も異常値
+    TEST_ASSERT_EQUAL_FLOAT(200.0f, convertVoltageToTemp(5.0f));
+}
+
+void setup() {
+    // テスト初期化
+    UNITY_BEGIN();
+    RUN_TEST(test_convertAdcToVoltage_nominal);
+    RUN_TEST(test_convertAdcToVoltage_negative);
+    RUN_TEST(test_convertVoltageToTemp_normal);
+    RUN_TEST(test_convertVoltageToTemp_invalid_low);
+    RUN_TEST(test_convertVoltageToTemp_invalid_high);
+    UNITY_END();
+}
+
+void loop() {
+    // ループ処理は使用しない
+}


### PR DESCRIPTION
## Summary (日本語/English)
- PlatformIO テスト環境を追加
- センサ変換関数 `convertAdcToVoltage` と `convertVoltageToTemp` の単体テストを作成
- CI ワークフローで `pio test` を実行

## Testing
- `pio test -e test` *(failed: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6872919f3be483229e388f91c18f2bda