### PR TITLE
油圧ショート判定追加 / Add oil pressure short detection

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -39,9 +39,10 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   const uint16_t TEXT_COLOR = COLOR_WHITE;        // テキストの色
   const uint16_t MAX_VALUE_COLOR = COLOR_RED;     // 未使用だが互換のため残置
 
+  bool valueShort = value <= -1.0f;   // ショート判定用
   bool valueError = value >= 199.0f;
-  if (valueError) {
-    // 異常値の場合は 0 として扱う
+  if (valueShort || valueError) {
+    // 異常値は 0 として扱い表示のみ置き換える
     value = 0.0f;
   }
 
@@ -189,7 +190,11 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
 
   // 値を右下に表示
   char valueText[10];
-  if (valueError) {
+  if (valueShort) {
+    // ショート発生時は "St" を表示
+    snprintf(valueText, sizeof(valueText), "St");
+  }
+  else if (valueError) {
     // 199℃以上は "DE" を表示
     snprintf(valueText, sizeof(valueText), "DE");
   }

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -41,6 +41,10 @@ float convertAdcToVoltage(int16_t rawAdc)
 
 float convertVoltageToOilPressure(float voltage)
 {
+    // 4.9V 以上はセンサーショートとみなす
+    if (voltage >= 4.9f) return -1.0f;  // ショート判定用の特殊値
+
+    // センサー実測式に基づき圧力へ変換
     return (voltage > 0.5f) ? 2.5f * (voltage - 0.5f) : 0.0f;
 }
 


### PR DESCRIPTION
## Summary / 概要
- 油圧センサー電圧が4.9V以上の場合はショートと判定し `St` 表示するようにしました
- `convertVoltageToOilPressure` で4.9V以上を検出して特殊値を返すよう変更
- `DrawFillArcMeter` にショート用表示処理を追加

## Testing / テスト
- `pio run -e m5stack-cores3` を実行しましたが、依存ライブラリ取得のためのネットワークアクセスがブロックされビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_68729b133d388322a8bcc58f31d49563