### PR TITLE
Fix: suppress deprecated warnings / 非推奨警告を抑制

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,5 +17,7 @@ lib_deps =
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
 lib_ldf_mode = deep
+; ライブラリの非推奨警告を抑制
+build_flags = -Wno-deprecated-declarations
 monitor_speed = 115200
 upload_port = COM11


### PR DESCRIPTION
## Summary / 概要
- add build flag to suppress deprecated warnings
- 非推奨警告を抑制するためのビルドフラグを追加

## Testing
- `pio run` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68731d37c69083228d6ce4eb9a5c9a70