### PR TITLE
FPS表示の重なり修正 / Fix FPS overlay overlap

### DIFF
--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -10,16 +10,19 @@ void drawFpsOverlay()
     mainCanvas.setFont(&fonts::Font0);
     mainCanvas.setTextSize(0);
 
+    // ラベルは画面下部の表示と被らないよう少し上へ移動
+    constexpr int FPS_Y = LCD_HEIGHT - 32;  // もとの表示より16px上
+
     if (!fpsLabelDrawn) {
         // 表示領域を初期化してラベルを描画
-        mainCanvas.fillRect(0, LCD_HEIGHT - 16, 80, 16, COLOR_BLACK);
-        mainCanvas.setCursor(5, LCD_HEIGHT - 16);
+        mainCanvas.fillRect(0, FPS_Y, 80, 16, COLOR_BLACK);
+        mainCanvas.setCursor(5, FPS_Y);
         mainCanvas.println("FPS:");
         fpsLabelDrawn = true;
     }
 
     // 数値表示部のみ塗り直して更新
-    mainCanvas.fillRect(5, LCD_HEIGHT - 8, 30, 8, COLOR_BLACK);
-    mainCanvas.setCursor(5, LCD_HEIGHT - 8);
+    mainCanvas.fillRect(5, FPS_Y + 8, 30, 8, COLOR_BLACK);
+    mainCanvas.setCursor(5, FPS_Y + 8);
     mainCanvas.printf("%d", currentFramesPerSecond);
 }


### PR DESCRIPTION
## Summary / 概要
- FPS表示がメーターラベルに重なる問題を修正しました
- Moved FPS overlay 16px upward so labels remain readable

## Testing / テスト
- `platformio run` (failed: network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68731d4a200083229c9d0f78751b547d