### PR TITLE
Add PlatformIO build workflow / PlatformIO ビルドワークフロー追加

### DIFF
--- a/.github/workflows/pio-build.yml
+++ b/.github/workflows/pio-build.yml
@@ -1,0 +1,50 @@
+name: PlatformIO Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: チェックアウト
+        uses: actions/checkout@v3
+
+      - name: Python を設定
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: pipキャッシュ
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: PlatformIOキャッシュ
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.platformio/packages
+          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
+
+      - name: PlatformIO インストール
+        run: pip install platformio
+
+      - name: ビルド
+        run: pio run -e m5stack-cores3
+
+      - name: ファームウェアをアーティファクトで保存
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          path: .pio/build/m5stack-cores3/firmware.bin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # M5Stack CoreS3 Multi-Gauge  
 # M5Stack CoreS3 マルチメーター
 
+[![PlatformIO Build](https://github.com/puriso/racing_guage/actions/workflows/pio-build.yml/badge.svg?branch=main)](https://github.com/puriso/racing_guage/actions/workflows/pio-build.yml)
+
 A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays:
 
 * **Oil Pressure** via **Defi PDF00903S** (0 – 9.9 bar, 0.5 – 4.5 V)


### PR DESCRIPTION
## Summary / 概要
- add GitHub Actions workflow for PlatformIO
- cache pip and PlatformIO directories
- upload firmware artifact
- add build status badge to README

## Testing / テスト
- `platformio run -e m5stack-cores3` *(failed: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687321a2aec48322ad88c8b26fa98ed1