### PR TITLE
油圧低下時に接続エラー表示 / Show 'DE' on low oil pressure

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -35,6 +35,8 @@ constexpr uint16_t COLOR_GRAY   = rgb565(169, 169, 169);
 constexpr float MAX_OIL_PRESSURE_DISPLAY = 15.0f;
 // メーター目盛の上限
 constexpr float MAX_OIL_PRESSURE_METER   = 10.0f;
+// 0.25bar 以下なら接続エラーとして扱う閾値
+constexpr float OIL_PRESSURE_DISCONNECT_THRESHOLD = 0.25f;
 
 // ── 水温メーター設定 ──
 // 水温メーター下限と上限を80℃〜105℃に設定

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -152,6 +152,10 @@ void updateGauges()
 
     float pressureAvg     = calculateAverage(oilPressureSamples);
     pressureAvg = std::min(pressureAvg, MAX_OIL_PRESSURE_DISPLAY);
+    // 油圧が極端に低い場合はセンサー未接続とみなす
+    bool pressureDisconnected =
+        (pressureAvg <= OIL_PRESSURE_DISCONNECT_THRESHOLD);
+    float pressureDisplay = pressureDisconnected ? 199.0f : pressureAvg;
     float targetWaterTemp = calculateAverage(waterTemperatureSamples);
     float targetOilTemp   = calculateAverage(oilTemperatureSamples);
 
@@ -167,12 +171,16 @@ void updateGauges()
         oilTempValue = 0.0f;
     }
 
-    recordedMaxOilPressure = std::max(recordedMaxOilPressure, pressureAvg);
+    if (!pressureDisconnected) {
+        // 正常値のみ最大記録を更新
+        recordedMaxOilPressure =
+            std::max(recordedMaxOilPressure, pressureAvg);
+    }
     recordedMaxWaterTemp   = std::max(recordedMaxWaterTemp, smoothWaterTemp);
     if (targetOilTemp < 199.0f) {
         recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
     }
 
-    renderDisplayAndLog(pressureAvg, smoothWaterTemp,
+    renderDisplayAndLog(pressureDisplay, smoothWaterTemp,
                         oilTempValue, recordedMaxOilTempTop);
 }


### PR DESCRIPTION
## Summary / 概要
- 油圧が0.25bar以下の場合は接続エラーとみなし"DE"を表示するよう変更
- `OIL_PRESSURE_DISCONNECT_THRESHOLD` 定数を追加
- 最大油圧記録の更新条件を調整

## Testing
- `platformio run` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873223fdc788322a7a43dab81493794