### PR TITLE
Fix mermaid wiring doc / 配線図修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,7 @@ This project is not licensed under the MIT License. All rights reserved by the a
 ---
 
 🚗 Built for performance, track use, and hobbyist tuning.
+
+## 配線図
+M5Stack CoreS3 と 3 種センサの接続例です。  
+👉 [docs/wiring.md](docs/wiring.md) を参照

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -1,0 +1,42 @@
+## M5Stack CoreS3 × 油圧・水温・油温センサ 配線図
+
+```mermaid
+graph LR
+    %% ===== Devices =====
+    subgraph Core
+        CoreS3["M5Stack<br>CoreS3"]
+    end
+
+    subgraph ADC
+        ADS1015["ADS1015<br>I²C&nbsp;ADC"]
+    end
+
+    subgraph Sensors
+        OilTemp["PDF00703S<br>油温"]
+        WaterTemp["PDF00703S<br>水温"]
+        OilPress["PDF00903S<br>油圧"]
+    end
+
+    %% ===== Analog channels =====
+    OilTemp  -- "A0 (AIN0)" --> ADS1015
+    WaterTemp -- "A1 (AIN1)" --> ADS1015
+    OilPress -- "A2 (AIN2)" --> ADS1015
+
+    %% ===== I²C bus =====
+    ADS1015 -- "SDA → GPIO9" --> CoreS3
+    ADS1015 -- "SCL → GPIO8" --> CoreS3
+
+    %% ===== Power rails =====
+    CoreS3 -.->|5 V| ADS1015
+    CoreS3 -.->|GND| ADS1015
+
+    ADS1015 -.->|5 V| OilTemp
+    ADS1015 -.->|5 V| WaterTemp
+    ADS1015 -.->|5 V| OilPress
+
+    ADS1015 -.->|GND| OilTemp
+    ADS1015 -.->|GND| WaterTemp
+    ADS1015 -.->|GND| OilPress
+```
+
+センサは 0.5 – 4.5 V の ratiometric 出力、ADS1015 は単電源 5 V 動作を想定。


### PR DESCRIPTION
## Summary / 概要
- fix Mermaid diagram in `docs/wiring.md`
- diagram renders correctly now with `mmdc`

## Testing / テスト
- `mmdc -i docs/wiring.md -o /tmp/test.png`
- `platformio run -e m5stack-cores3` *(failed: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6873267075f083229a365e998e67a793