### PR TITLE
fix: correct skip uploading flag / テストCIのフラグ修正

### DIFF
--- a/.github/workflows/pio-test.yml
+++ b/.github/workflows/pio-test.yml
@@ -1,0 +1,44 @@
+name: PlatformIO Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: チェックアウト
+        uses: actions/checkout@v3
+
+      - name: Python を設定
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: pipキャッシュ
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: PlatformIOキャッシュ
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.platformio/packages
+          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
+
+      - name: PlatformIO インストール
+        run: pip install platformio
+
+      - name: テスト実行
+        run: pio test -e m5stack-cores3 --without-uploading

--- a/include/sensor_conversion.h
+++ b/include/sensor_conversion.h
@@ -1,0 +1,11 @@
+#ifndef SENSOR_CONVERSION_H
+#define SENSOR_CONVERSION_H
+
+#include <cmath>
+#include <cstdint>
+
+float adc_to_oil_press(int adc);
+float adc_to_water_temp(int adc);
+float adc_to_oil_temp(int adc);
+
+#endif  // SENSOR_CONVERSION_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,10 @@ lib_deps =
   m5stack/M5Unified@^0.1.17
   m5stack/M5CoreS3@^1.0.0
   adafruit/Adafruit ADS1X15@^2.5.0
-lib_ldf_mode = deep
 monitor_speed = 115200
 upload_port = COM11
+
+; ---- Unit test settings ----
+test_build_src = no
+lib_ldf_mode           = deep+
+test_skip_uploading    = yes

--- a/src/sensor_conversion.cpp
+++ b/src/sensor_conversion.cpp
@@ -1,0 +1,35 @@
+#include "sensor_conversion.h"
+
+// ────────────────────── 定数定義 ──────────────────────
+constexpr float SUPPLY_VOLTAGE = 5.0f;  // 電源電圧 [V]
+constexpr float ADC_MAX = 4095.0f;      // ADC 最大値
+
+// 水温・油温計算用の二次近似係数
+constexpr float TEMP_COEF_A = -5.6666667f;
+constexpr float TEMP_COEF_B = 75.8333333f;
+constexpr float TEMP_COEF_C = -76.5f;
+
+// ADC 値を電圧へ変換
+static inline float adc_to_voltage(int adc) { return (static_cast<float>(adc) / ADC_MAX) * SUPPLY_VOLTAGE; }
+
+// 油圧変換 [bar]
+float adc_to_oil_press(int adc)
+{
+  if (adc < 0 || adc > ADC_MAX) return std::nanf("");
+
+  float voltage = adc_to_voltage(adc);
+  if (voltage < 0.5f) return 0.0f;
+  return 2.5f * (voltage - 0.5f);
+}
+
+// 水温変換 [℃]
+float adc_to_water_temp(int adc)
+{
+  if (adc < 0 || adc > ADC_MAX) return std::nanf("");
+
+  float voltage = adc_to_voltage(adc);
+  return TEMP_COEF_A * voltage * voltage + TEMP_COEF_B * voltage + TEMP_COEF_C;
+}
+
+// 油温変換 [℃]（水温と同じ計算式）
+float adc_to_oil_temp(int adc) { return adc_to_water_temp(adc); }

--- a/test/test_arduino_stub.cpp
+++ b/test/test_arduino_stub.cpp
@@ -1,0 +1,9 @@
+#include <Arduino.h>
+
+void setup() {
+    // 何もしないダミー実装
+}
+
+void loop() {
+    // 何もしないダミー実装
+}

--- a/test/test_sensor_conversion.cpp
+++ b/test/test_sensor_conversion.cpp
@@ -1,0 +1,41 @@
+#include <unity.h>
+#include "sensor_conversion.h"
+
+void test_oil_pressure() {
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, adc_to_oil_press(409));   // 0 bar
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 5.0f, adc_to_oil_press(2048));  // 5 bar
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 9.9f, adc_to_oil_press(3686));  // 9.9 bar
+}
+
+// 水温のテスト
+void test_water_temp() {
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, -40.0f, adc_to_water_temp(409));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 100.0f, adc_to_water_temp(2457));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 150.0f, adc_to_water_temp(3686));
+}
+
+// 油温のテスト（計算式は水温と共通）
+void test_oil_temp() {
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, -40.0f, adc_to_oil_temp(409));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 100.0f, adc_to_oil_temp(2457));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 150.0f, adc_to_oil_temp(3686));
+}
+
+void test_invalid() {
+    TEST_ASSERT_TRUE(isnan(adc_to_oil_press(-1)));
+    TEST_ASSERT_TRUE(isnan(adc_to_oil_press(5000)));
+    TEST_ASSERT_TRUE(isnan(adc_to_water_temp(-10)));
+    TEST_ASSERT_TRUE(isnan(adc_to_water_temp(5000)));
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_oil_pressure);
+    RUN_TEST(test_water_temp);
+    RUN_TEST(test_oil_temp);
+    RUN_TEST(test_invalid);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- replace `--without-upload` with `--without-uploading` in workflow
- add `test_skip_uploading = yes` to PlatformIO config

## 概要
- GitHub Actions で誤っていたフラグを修正し、アップロード工程を完全に無効化
- `platformio.ini` にテスト用オプションを追加

## Testing
- `pip install platformio`
- `pio test -e m5stack-cores3 --without-uploading` *(failed: HTTPClientError while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687322d9a63c832285963601cd6dd322