### PR TITLE
表示エラー文字の拡充 / Expand error messages

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -190,13 +190,20 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
 
   // 値を右下に表示
   char valueText[10];
+  char errorLine1[20];
+  char errorLine2[8];
+  bool isErrorText = false;
   if (valueShort) {
-    // ショート発生時は "St" を表示
-    snprintf(valueText, sizeof(valueText), "St");
+    // ショート発生時は "Short circuit\nError" を表示
+    snprintf(errorLine1, sizeof(errorLine1), "Short circuit");
+    snprintf(errorLine2, sizeof(errorLine2), "Error");
+    isErrorText = true;
   }
   else if (valueError) {
-    // 199℃以上は "DE" を表示
-    snprintf(valueText, sizeof(valueText), "DE");
+    // 199℃以上は "Disconnection\nError" を表示
+    snprintf(errorLine1, sizeof(errorLine1), "Disconnection");
+    snprintf(errorLine2, sizeof(errorLine2), "Error");
+    isErrorText = true;
   }
   else if (useDecimal)
   {
@@ -207,14 +214,30 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
     snprintf(valueText, sizeof(valueText), "%.0f", round(value));
   }
 
-  canvas.setFont(&FreeSansBold24pt7b);
   int valueX = VALUE_BASE_X;  // 数字は固定位置に表示
   int valueY = CENTER_Y_CORRECTED + RADIUS - 20;
-  // 数字描画領域のみを毎回黒で塗りつぶす
-  canvas.fillRect(valueX - 75, valueY - canvas.fontHeight() / 2 - 2,
-                  75, canvas.fontHeight() + 4, BACKGROUND_COLOR);
-  canvas.setCursor(valueX - canvas.textWidth(valueText), valueY - (canvas.fontHeight() / 2));
-  canvas.print(valueText);
+
+  if (isErrorText) {
+    // エラー表示用フォントを小さく設定
+    canvas.setFont(&fonts::Font0);
+    int rectHeight = canvas.fontHeight() * 2 + 4;
+    canvas.fillRect(valueX - 75, valueY - canvas.fontHeight() - 2,
+                    75, rectHeight, BACKGROUND_COLOR);
+    int line1Y = valueY - canvas.fontHeight();
+    canvas.setCursor(valueX - canvas.textWidth(errorLine1), line1Y);
+    canvas.print(errorLine1);
+    int line2Y = line1Y + canvas.fontHeight();
+    canvas.setCursor(valueX - canvas.textWidth(errorLine2), line2Y);
+    canvas.print(errorLine2);
+  } else {
+    canvas.setFont(&FreeSansBold24pt7b);
+    // 数字描画領域のみを毎回黒で塗りつぶす
+    canvas.fillRect(valueX - 75, valueY - canvas.fontHeight() / 2 - 2,
+                    75, canvas.fontHeight() + 4, BACKGROUND_COLOR);
+    canvas.setCursor(valueX - canvas.textWidth(valueText),
+                    valueY - (canvas.fontHeight() / 2));
+    canvas.print(valueText);
+  }
 
 }
 

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -71,17 +71,19 @@ void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp)
 
     canvas.setCursor(X, Y + H + 4);
     canvas.printf("OIL.T / Celsius,  MAX:%03d", maxOilTemp);
-    char tempStr[6];
+    char tempStr[8];
     // snprintf でバッファサイズを指定し、
     // 安全に文字列化する
-    // 199℃以上は異常値として "DE" を表示
     if (oilTemp >= 199.0f) {
-        snprintf(tempStr, sizeof(tempStr), "DE");
+        // 199℃以上は "Disconnection" と "Error" を小さなフォントで表示
+        canvas.setFont(&fonts::Font0);
+        canvas.drawRightString("Disconnection", LCD_WIDTH - 1, 2);
+        canvas.drawRightString("Error", LCD_WIDTH - 1, 2 + canvas.fontHeight());
     } else {
         snprintf(tempStr, sizeof(tempStr), "%d", static_cast<int>(oilTemp));
+        canvas.setFont(&FreeSansBold24pt7b);
+        canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
     }
-    canvas.setFont(&FreeSansBold24pt7b);
-    canvas.drawRightString(tempStr, LCD_WIDTH - 1, 2);
 }
 
 // ────────────────────── 画面更新＋ログ ──────────────────────


### PR DESCRIPTION
## 概要 / Summary
- 油温ゲージや圧力ゲージの異常表示を `DE`/`St` から
  `Disconnection\nError` / `Short circuit\nError` へ変更しました
- オイル温度バーで 199℃ 以上の場合も同様に二行表示します

## Testing
- `platformio` をインストール
- `pio run` 実行を試みましたが、外部リポジトリへのアクセスが制限され失敗しました

------
https://chatgpt.com/codex/tasks/task_e_6874695134c4832287c844cf07ed8aa0