### PR TITLE
Add CI path ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: Build firmware
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/pio-build.yml
+++ b/.github/workflows/pio-build.yml
@@ -3,8 +3,12 @@ name: PlatformIO Build
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary / 概要
- exclude markdown files from CI triggers
- CI が `.md` 変更のみで動作しないように設定

## Testing
- `pio run -e m5stack-cores3` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687481c2574c83228b90c54b1208b8d7