### PR TITLE
油圧ショート検出と温度エラー処理を修正 / Fix short and temp error logic

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <cstring>
 
 // std::clamp が利用できない環境向けの簡易版
 template <typename T>
@@ -39,9 +40,12 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   const uint16_t TEXT_COLOR = COLOR_WHITE;        // テキストの色
   const uint16_t MAX_VALUE_COLOR = COLOR_RED;     // 未使用だが互換のため残置
 
-  // 値が 12bar 以上ならショートとみなす
-  bool valueShort = value >= 12.0f;
-  bool valueError = value >= 199.0f;
+  // 油圧だったら short(12bar 以上) かどうか、
+  // 温度計だったら 199℃ 以上かどうかをチェックする
+  bool isPressureGauge = strcmp(label, "OIL.P") == 0;
+  bool isTempGauge     = strcmp(unit, "Celsius") == 0;
+  bool valueShort = isPressureGauge && value >= 12.0f;
+  bool valueError = isTempGauge && value >= 199.0f;
   if (valueShort || valueError) {
     // 異常値は 0 として扱い表示のみ置き換える
     value = 0.0f;

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -39,7 +39,8 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   const uint16_t TEXT_COLOR = COLOR_WHITE;        // テキストの色
   const uint16_t MAX_VALUE_COLOR = COLOR_RED;     // 未使用だが互換のため残置
 
-  bool valueShort = value <= -1.0f;   // ショート判定用
+  // 値が 12bar 以上ならショートとみなす
+  bool valueShort = value >= 12.0f;
   bool valueError = value >= 199.0f;
   if (valueShort || valueError) {
     // 異常値は 0 として扱い表示のみ置き換える
@@ -194,7 +195,8 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   char errorLine2[8];
   bool isErrorText = false;
   if (valueShort) {
-    // ショート発生時は "Short circuit\nError" を表示
+    // 12bar 以上のショートエラー表示
+    // "Short circuit\nError" を表示
     snprintf(errorLine1, sizeof(errorLine1), "Short circuit");
     snprintf(errorLine2, sizeof(errorLine2), "Error");
     isErrorText = true;

--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -40,25 +40,12 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   const uint16_t TEXT_COLOR = COLOR_WHITE;        // テキストの色
   const uint16_t MAX_VALUE_COLOR = COLOR_RED;     // 未使用だが互換のため残置
 
-  // 油圧だったら short(12bar 以上) かどうか、
-  // 温度計だったら 199℃ 以上かどうかをチェックする
-  bool isPressureGauge = strcmp(label, "OIL.P") == 0;
-  bool isTempGauge     = strcmp(unit, "Celsius") == 0;
-  bool valueShort = isPressureGauge && value >= 12.0f;
-  bool valueError = isTempGauge && value >= 199.0f;
-  if (valueShort || valueError) {
-    // 異常値は 0 として扱い表示のみ置き換える
-    value = 0.0f;
-  }
-
   // 値を範囲内に収める
   float clampedValue = value;
   if (clampedValue < minValue)
     clampedValue = minValue;
   else if (clampedValue > maxValue)
     clampedValue = maxValue;
-  // 最大値を更新（範囲外の場合でも最大角度で保持）
-  maxRecordedValue = std::max(clampedValue, maxRecordedValue);
 
   // 初回は全体を描画してキャッシュを初期化
   if (drawStatic || std::isnan(previousValue)) {
@@ -198,14 +185,14 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   char errorLine1[20];
   char errorLine2[8];
   bool isErrorText = false;
-  if (valueShort) {
+  if (unit == "BAR" && value >= 11.0f) {
     // 12bar 以上のショートエラー表示
     // "Short circuit\nError" を表示
     snprintf(errorLine1, sizeof(errorLine1), "Short circuit");
     snprintf(errorLine2, sizeof(errorLine2), "Error");
     isErrorText = true;
   }
-  else if (valueError) {
+  else if (unit == "Celsius" && value >= 199.0f) {
     // 199℃以上は "Disconnection\nError" を表示
     snprintf(errorLine1, sizeof(errorLine1), "Disconnection");
     snprintf(errorLine2, sizeof(errorLine2), "Error");

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -154,10 +154,13 @@ void updateGauges()
 
     float pressureAvg     = calculateAverage(oilPressureSamples);
     pressureAvg = std::min(pressureAvg, MAX_OIL_PRESSURE_DISPLAY);
+    // 12bar 以上はショート扱い
+    bool pressureShort = (pressureAvg >= 12.0f);
     // 油圧が極端に低い場合はセンサー未接続とみなす
     bool pressureDisconnected =
-        (pressureAvg <= OIL_PRESSURE_DISCONNECT_THRESHOLD);
-    float pressureDisplay = pressureDisconnected ? 199.0f : pressureAvg;
+        (!pressureShort && pressureAvg <= OIL_PRESSURE_DISCONNECT_THRESHOLD);
+    float pressureDisplay =
+        pressureDisconnected ? 199.0f : pressureAvg;
     float targetWaterTemp = calculateAverage(waterTemperatureSamples);
     float targetOilTemp   = calculateAverage(oilTemperatureSamples);
 
@@ -173,7 +176,7 @@ void updateGauges()
         oilTempValue = 0.0f;
     }
 
-    if (!pressureDisconnected) {
+    if (!pressureDisconnected && !pressureShort) {
         // 正常値のみ最大記録を更新
         recordedMaxOilPressure =
             std::max(recordedMaxOilPressure, pressureAvg);

--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -154,13 +154,6 @@ void updateGauges()
 
     float pressureAvg     = calculateAverage(oilPressureSamples);
     pressureAvg = std::min(pressureAvg, MAX_OIL_PRESSURE_DISPLAY);
-    // 12bar 以上はショート扱い
-    bool pressureShort = (pressureAvg >= 12.0f);
-    // 油圧が極端に低い場合はセンサー未接続とみなす
-    bool pressureDisconnected =
-        (!pressureShort && pressureAvg <= OIL_PRESSURE_DISCONNECT_THRESHOLD);
-    float pressureDisplay =
-        pressureDisconnected ? 199.0f : pressureAvg;
     float targetWaterTemp = calculateAverage(waterTemperatureSamples);
     float targetOilTemp   = calculateAverage(oilTemperatureSamples);
 
@@ -176,16 +169,13 @@ void updateGauges()
         oilTempValue = 0.0f;
     }
 
-    if (!pressureDisconnected && !pressureShort) {
-        // 正常値のみ最大記録を更新
-        recordedMaxOilPressure =
-            std::max(recordedMaxOilPressure, pressureAvg);
-    }
+    recordedMaxOilPressure =
+        std::max(recordedMaxOilPressure, pressureAvg);
     recordedMaxWaterTemp   = std::max(recordedMaxWaterTemp, smoothWaterTemp);
     if (targetOilTemp < 199.0f) {
         recordedMaxOilTempTop = std::max(recordedMaxOilTempTop, static_cast<int>(targetOilTemp));
     }
 
-    renderDisplayAndLog(pressureDisplay, smoothWaterTemp,
+    renderDisplayAndLog(pressureAvg, smoothWaterTemp,
                         oilTempValue, recordedMaxOilTempTop);
 }

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -41,8 +41,8 @@ float convertAdcToVoltage(int16_t rawAdc)
 
 float convertVoltageToOilPressure(float voltage)
 {
-    // 4.9V 以上はセンサーショートとみなす
-    if (voltage >= 4.9f) return -1.0f;  // ショート判定用の特殊値
+    // 電源電圧近くまで上昇してもそのまま変換し、
+    // 12bar 以上かどうかは呼び出し側で判断する
 
     // センサー実測式に基づき圧力へ変換
     return (voltage > 0.5f) ? 2.5f * (voltage - 0.5f) : 0.0f;


### PR DESCRIPTION
## 概要 / Summary
- 油圧が12bar以上ならショートとして扱うよう変更
- 温度が199℃を超えた場合に未接続エラー表示
- センサー変換関数からショート判定用の特殊値を削除

## Testing
- `pio run -e m5stack-cores3` *(failed: HTTPClientError while fetching PlatformIO packages)*

------
https://chatgpt.com/codex/tasks/task_e_68747d0ae0888322afbe07e5c779dbc3