### PR TITLE
CI用テスト設定修正 / Fix CI test setup

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,15 @@ lib_deps =
 lib_ldf_mode = deep
 monitor_speed = 115200
 upload_port = COM11
+
+[env:m5stack-cores3-ci]
+platform = espressif32
+board = m5stack-cores3
+framework = arduino
+lib_deps =
+  m5stack/M5Unified@^0.1.17
+  m5stack/M5CoreS3@^1.0.0
+  adafruit/Adafruit ADS1X15@^2.5.0
+lib_ldf_mode = deep
+monitor_speed = 115200
+test_filter = ci_dummy

--- a/test/ci_dummy/test_dummy.cpp
+++ b/test/ci_dummy/test_dummy.cpp
@@ -1,0 +1,16 @@
+#include <unity.h>
+
+void test_dummy(void) {
+    // 何もしない
+    TEST_ASSERT_TRUE(true);
+}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_dummy);
+    UNITY_END();
+}
+
+void loop() {
+    // テストループは空
+}


### PR DESCRIPTION
## 概要 / Summary
- `platformio.ini` に `m5stack-cores3-ci` 環境を追加し、`test_filter` を `ci_dummy` に設定しました
- `test/ci_dummy/test_dummy.cpp` を新規追加し、ダミーテストを実装しました

## テスト / Testing
- `pio test -e m5stack-cores3-ci --without-uploading --without-testing` を実行しましたが、ネットワーク制限のため依存パッケージを取得できずビルドは失敗しました


------
https://chatgpt.com/codex/tasks/task_e_6875ebb35a908322807a5a59db7e7544