### PR TITLE
Add PlatformIO Test Workflow / PlatformIO テストワークフローを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: PlatformIO Test
+
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: チェックアウト
+        uses: actions/checkout@v3
+
+      - name: Python を設定
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: pipキャッシュ
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: PlatformIOキャッシュ
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.platformio/packages
+          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
+        # ネットワークが制限される環境では上記ディレクトリを事前に用意してください
+
+      - name: PlatformIO インストール
+        run: pip install platformio
+
+      - name: テスト実行
+        run: pio test -e m5stack-cores3

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ graph TD
 ### ビルド方法
 1. [PlatformIO](https://platformio.org/) をインストール (VS Code 推奨)
 2. `platformio run` でビルドし、`platformio upload` で書き込み
+3. ネットワーク制限環境では `~/.platformio/packages` を事前に配置してください
 
 ---
 
@@ -194,6 +195,7 @@ The temperature sensor is a thermistor; typical resistance values are shown belo
 ### Build Instructions
 1. Install [PlatformIO](https://platformio.org/) (VS Code recommended)
 2. Build with `platformio run` and flash with `platformio upload`
+3. In network restricted environments, pre-populate `~/.platformio/packages`
 
 ---
 


### PR DESCRIPTION
## Summary / 概要
- add GitHub Actions workflow for running `pio test`
- cache `~/.platformio/packages` and document that offline environments must pre-populate the directory
- mention the same requirement in README

## Testing
- `pip install platformio`
- `pio run -e m5stack-cores3` *(failed: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6875ebb4ff94832299f1eac0502522a8