### PR TITLE
スプライト転送条件の修正 / Fix sprite push condition

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -143,7 +143,10 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
         drawFpsOverlay();
     }
 
-    mainCanvas.pushSprite(0, 0);
+    // 値が更新されたときのみスプライトを転送する
+    if (oilChanged || pressureChanged || waterChanged) {
+        mainCanvas.pushSprite(0, 0);
+    }
 }
 
 // ────────────────────── メーター描画更新 ──────────────────────


### PR DESCRIPTION
## Summary
- 日本語: 値が変化したときのみスプライトを転送するよう修正
- English: push sprite only when values change

## Testing
- `pio run` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875ed737dd48322baac58900fe6b4e9