### PR TITLE
油圧センサーの切断判定追加 / Add oil pressure disconnect check

### DIFF
--- a/src/DrawFillArcMeter.h
+++ b/src/DrawFillArcMeter.h
@@ -2,6 +2,7 @@
 #define DRAW_FILL_ARC_METER_H
 
 #include <M5GFX.h>  // 必要なライブラリをインクルード
+#include "config.h" // 閾値定義を利用する
 
 #include <algorithm>
 #include <cmath>
@@ -185,7 +186,14 @@ void drawFillArcMeter(M5Canvas &canvas, float value, float minValue, float maxVa
   char errorLine2[8];
   bool isErrorText = false;
   // 文字列比較は strcmp を使用する
-  if (strcmp(unit, "BAR") == 0 && value >= 11.0f) {
+  if (strcmp(unit, "BAR") == 0 &&
+      value <= OIL_PRESSURE_DISCONNECT_THRESHOLD) {
+    // 規定圧未満は "Disconnection\nError" を表示
+    snprintf(errorLine1, sizeof(errorLine1), "Disconnection");
+    snprintf(errorLine2, sizeof(errorLine2), "Error");
+    isErrorText = true;
+  }
+  else if (strcmp(unit, "BAR") == 0 && value >= 11.0f) {
     // 12bar 以上のショートエラー表示
     // "Short circuit\nError" を表示
     snprintf(errorLine1, sizeof(errorLine1), "Short circuit");

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -44,6 +44,9 @@ static float convertVoltageToOilPressure(float voltage)
     // 電源電圧近くまで上昇してもそのまま変換し、
     // 12bar 以上かどうかは呼び出し側で判断する
 
+    // 0.4V 未満はセンサー切断とみなし 0 bar とする
+    if (voltage < 0.4f) return 0.0f;
+
     // センサー実測式に基づき圧力へ変換
     return (voltage > 0.5f) ? 2.5f * (voltage - 0.5f) : 0.0f;
 }


### PR DESCRIPTION
## 概要 / Summary
- 0.4V 未満をセンサー切断とみなす処理を追加
- 油圧が規定値以下の場合に `Disconnection` エラーを表示

## テスト / Testing
- `platformio test` 実行を試みましたが、依存パッケージ取得に失敗しました

------
https://chatgpt.com/codex/tasks/task_e_6877b2dd3fc08322b960af75974caa15