### PR TITLE
Always show FPS overlay / FPS表示を常時表示

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -139,12 +139,10 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
         displayCache.waterTempAvg = waterTempAvg;
     }
 
-    if (DEBUG_MODE_ENABLED) {
-        drawFpsOverlay();
-    }
+    bool fpsChanged = drawFpsOverlay();
 
     // 値が更新されたときのみスプライトを転送する
-    if (oilChanged || pressureChanged || waterChanged) {
+    if (oilChanged || pressureChanged || waterChanged || fpsChanged) {
         mainCanvas.pushSprite(0, 0);
     }
 }

--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -1,11 +1,13 @@
 #include "fps_display.h"
 #include "display.h"
+#include <M5CoreS3.h>
 
 // FPSラベルが描画済みかどうかを保持
 static bool fpsLabelDrawn = false;
+static unsigned long previousFpsDrawTime = 0;
 
 // ────────────────────── FPS表示 ──────────────────────
-void drawFpsOverlay()
+bool drawFpsOverlay()
 {
     mainCanvas.setFont(&fonts::Font0);
     mainCanvas.setTextSize(0);
@@ -13,16 +15,24 @@ void drawFpsOverlay()
     // ラベルは画面下部の表示と被らないよう少し上へ移動
     constexpr int FPS_Y = LCD_HEIGHT - 32;  // もとの表示より16px上
 
+    unsigned long now = millis();
+
     if (!fpsLabelDrawn) {
         // 表示領域を初期化してラベルを描画
         mainCanvas.fillRect(0, FPS_Y, 80, 16, COLOR_BLACK);
         mainCanvas.setCursor(5, FPS_Y);
         mainCanvas.println("FPS:");
         fpsLabelDrawn = true;
+        previousFpsDrawTime = 0; // 初回はすぐ更新するため0に設定
     }
 
-    // 数値表示部のみ塗り直して更新
-    mainCanvas.fillRect(5, FPS_Y + 8, 30, 8, COLOR_BLACK);
-    mainCanvas.setCursor(5, FPS_Y + 8);
-    mainCanvas.printf("%d", currentFramesPerSecond);
+    if (now - previousFpsDrawTime >= 1000UL) {
+        // 数値表示部のみ塗り直して更新
+        mainCanvas.fillRect(5, FPS_Y + 8, 30, 8, COLOR_BLACK);
+        mainCanvas.setCursor(5, FPS_Y + 8);
+        mainCanvas.printf("%d", currentFramesPerSecond);
+        previousFpsDrawTime = now;
+        return true;
+    }
+    return false;
 }

--- a/src/modules/fps_display.h
+++ b/src/modules/fps_display.h
@@ -1,6 +1,7 @@
 #ifndef FPS_DISPLAY_H
 #define FPS_DISPLAY_H
 
-void drawFpsOverlay();
+// FPS表示を更新したかどうかを返す
+bool drawFpsOverlay();
 
 #endif // FPS_DISPLAY_H


### PR DESCRIPTION
## Summary / 概要
- update `drawFpsOverlay` to return whether display changed and refresh only once per second
- always call `drawFpsOverlay` and push sprite when FPS changed

## Testing / テスト
- `pio run -e m5stack-cores3-ci` *(failed: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6878989b0420832289952da142ba89fc