### PR TITLE
表示更新の閾値調整 / Adjust display update threshold

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -93,13 +93,14 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     const int TOPBAR_Y = 0, TOPBAR_H = 50;
     const int GAUGE_H  = 170;
 
+    // 変化量が0.1未満の場合も更新するため、閾値を0.1fに調整
     bool oilChanged = std::isnan(displayCache.oilTemp) ||
-                      fabs(oilTemp - displayCache.oilTemp) > 0.99f ||
+                      fabs(oilTemp - displayCache.oilTemp) >= 0.1f ||
                       (maxOilTemp != displayCache.maxOilTemp);
     bool pressureChanged = std::isnan(displayCache.pressureAvg) ||
-                           fabs(pressureAvg - displayCache.pressureAvg) > 0.09f;
+                           fabs(pressureAvg - displayCache.pressureAvg) >= 0.1f;
     bool waterChanged    = std::isnan(displayCache.waterTempAvg) ||
-                           fabs(waterTempAvg - displayCache.waterTempAvg) > 0.99f;
+                           fabs(waterTempAvg - displayCache.waterTempAvg) >= 0.1f;
 
     mainCanvas.setTextColor(COLOR_WHITE);
 


### PR DESCRIPTION
## Summary / 概要
- 変化量が0.1未満でも更新されるよう閾値を調整しました
- Adjusted gauge update thresholds to trigger when differences are below 0.1

## Testing / テスト
- `pio test -e m5stack-cores3-ci` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687882e55be48322a2705bcd6f5b78a7