### PR TITLE
FPS表示位置の修正 / Fix FPS overlay position

### DIFF
--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -15,7 +15,8 @@ void drawFpsOverlay()
 
     if (!fpsLabelDrawn) {
         // 表示領域を初期化してラベルを描画
-        mainCanvas.fillRect(0, FPS_Y, 80, 16, COLOR_BLACK);
+        // 文字列長に合わせて最小限の横幅でクリアする
+        mainCanvas.fillRect(0, FPS_Y, 50, 16, COLOR_BLACK);
         mainCanvas.setCursor(5, FPS_Y);
         mainCanvas.println("FPS:");
         fpsLabelDrawn = true;

--- a/src/modules/fps_display.cpp
+++ b/src/modules/fps_display.cpp
@@ -10,8 +10,8 @@ void drawFpsOverlay()
     mainCanvas.setFont(&fonts::Font0);
     mainCanvas.setTextSize(0);
 
-    // ラベルは画面下部の表示と被らないよう少し上へ移動
-    constexpr int FPS_Y = LCD_HEIGHT - 32;  // もとの表示より16px上
+    // ラベルがメーターに重ならないよう画面最下部へ配置
+    constexpr int FPS_Y = LCD_HEIGHT - 16;  // 下端に合わせる
 
     if (!fpsLabelDrawn) {
         // 表示領域を初期化してラベルを描画


### PR DESCRIPTION
## 概要 / Summary
FPS表示がメーターに重ならないよう、表示位置を画面下端に変更しました。
Moved the FPS overlay to the bottom of the screen so it no longer overlaps the gauge.


------
https://chatgpt.com/codex/tasks/task_e_6878982381e48322a9bbad3e9fd70dc4