### PR TITLE
ゲージ更新の閾値を調整 / Adjust gauge update thresholds

### DIFF
--- a/src/modules/display.cpp
+++ b/src/modules/display.cpp
@@ -93,14 +93,14 @@ void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
     const int TOPBAR_Y = 0, TOPBAR_H = 50;
     const int GAUGE_H  = 170;
 
-    // 温度は1度以上、油圧は0.1以上変化したら更新する
+    // 温度は0.1度以上、油圧は0.05以上変化したら更新する
     bool oilChanged = std::isnan(displayCache.oilTemp) ||
-                      fabs(oilTemp - displayCache.oilTemp) >= 1.0f ||
+                      fabs(oilTemp - displayCache.oilTemp) >= 0.1f ||
                       (maxOilTemp != displayCache.maxOilTemp);
     bool pressureChanged = std::isnan(displayCache.pressureAvg) ||
-                           fabs(pressureAvg - displayCache.pressureAvg) >= 0.1f;
+                           fabs(pressureAvg - displayCache.pressureAvg) >= 0.05f;
     bool waterChanged    = std::isnan(displayCache.waterTempAvg) ||
-                           fabs(waterTempAvg - displayCache.waterTempAvg) >= 1.0f;
+                           fabs(waterTempAvg - displayCache.waterTempAvg) >= 0.1f;
 
     mainCanvas.setTextColor(COLOR_WHITE);
 


### PR DESCRIPTION
## 概要 / Summary
- 画面更新条件の温度差を1℃から0.1℃、油圧差を0.05barに変更し、温度計の動きを滑らかにしました。

## テスト / Testing
- `pio run -e m5stack-cores3` *(failed: network access blocked)*
- `pio test` *(failed: network access blocked)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.


------
https://chatgpt.com/codex/tasks/task_e_6878e89717cc8322bdb6b1d53e2d3005