### PR TITLE
Add smooth backlight transition / バックライト遷移を滑らかに

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -63,6 +63,11 @@ constexpr uint8_t  BACKLIGHT_NIGHT =  60;
 
 constexpr int MEDIAN_BUFFER_SIZE = 10;
 
+// バックライト平滑化係数（指数移動平均）
+constexpr float BACKLIGHT_FILTER_ALPHA = 0.3f;
+// 1 回の更新で変化させる最大輝度値
+constexpr uint8_t BACKLIGHT_TRANSITION_SPEED = 5;
+
 // ── ADS1015 のチャンネル定義 ──
 constexpr uint8_t ADC_CH_WATER_TEMP   = 1;
 constexpr uint8_t ADC_CH_OIL_PRESSURE = 2;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -2,11 +2,14 @@
 #include "display.h"
 #include <cstring>
 #include <algorithm>
+#include <cmath>
 
 // ────────────────────── グローバル変数 ──────────────────────
 BrightnessMode currentBrightnessMode = BrightnessMode::Day;
 uint16_t luxSampleBuffer[MEDIAN_BUFFER_SIZE] = {};
 int luxSampleIndex = 0;
+static float smoothBrightness = BACKLIGHT_DAY;
+static uint8_t targetBrightness = BACKLIGHT_DAY;
 
 
 // ────────────────────── 輝度測定 ──────────────────────
@@ -25,33 +28,48 @@ static uint16_t measureLuxWithoutBacklight()
 void updateBacklightLevel()
 {
     if (!SENSOR_AMBIENT_LIGHT_PRESENT) {
-        if (currentBrightnessMode != BrightnessMode::Day) {
-            currentBrightnessMode = BrightnessMode::Day;
-            display.setBrightness(BACKLIGHT_DAY);
+        // ALS 無効時は常に昼モード
+        currentBrightnessMode = BrightnessMode::Day;
+        targetBrightness      = BACKLIGHT_DAY;
+    } else {
+        uint16_t lux = measureLuxWithoutBacklight();
+
+        luxSampleBuffer[luxSampleIndex] = lux;
+        luxSampleIndex = (luxSampleIndex + 1) % MEDIAN_BUFFER_SIZE;
+
+        uint16_t sorted[MEDIAN_BUFFER_SIZE];
+        memcpy(sorted, luxSampleBuffer, sizeof(sorted));
+        std::nth_element(sorted, sorted + MEDIAN_BUFFER_SIZE / 2,
+                        sorted + MEDIAN_BUFFER_SIZE);
+        uint16_t medianLux = sorted[MEDIAN_BUFFER_SIZE / 2];
+
+        BrightnessMode newMode =
+            (medianLux >= LUX_THRESHOLD_DAY)  ? BrightnessMode::Day  :
+            (medianLux >= LUX_THRESHOLD_DUSK) ? BrightnessMode::Dusk : BrightnessMode::Night;
+
+        if (newMode != currentBrightnessMode) {
+            currentBrightnessMode = newMode;
+            targetBrightness =
+                (newMode == BrightnessMode::Day)  ? BACKLIGHT_DAY  :
+                (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK : BACKLIGHT_NIGHT;
         }
-        return;
     }
 
-    uint16_t lux = measureLuxWithoutBacklight();
+    // 目標輝度へ徐々に近づける
+    float diff = static_cast<float>(targetBrightness) - smoothBrightness;
+    float step = diff * BACKLIGHT_FILTER_ALPHA;
 
-    luxSampleBuffer[luxSampleIndex] = lux;
-    luxSampleIndex = (luxSampleIndex + 1) % MEDIAN_BUFFER_SIZE;
+    if (step > BACKLIGHT_TRANSITION_SPEED)
+        step = BACKLIGHT_TRANSITION_SPEED;
+    else if (step < -BACKLIGHT_TRANSITION_SPEED)
+        step = -BACKLIGHT_TRANSITION_SPEED;
 
-    uint16_t sorted[MEDIAN_BUFFER_SIZE];
-    memcpy(sorted, luxSampleBuffer, sizeof(sorted));
-    std::nth_element(sorted, sorted + MEDIAN_BUFFER_SIZE / 2, sorted + MEDIAN_BUFFER_SIZE);
-    uint16_t medianLux = sorted[MEDIAN_BUFFER_SIZE / 2];
-
-    BrightnessMode newMode =
-        (medianLux >= LUX_THRESHOLD_DAY)  ? BrightnessMode::Day  :
-        (medianLux >= LUX_THRESHOLD_DUSK) ? BrightnessMode::Dusk : BrightnessMode::Night;
-
-    if (newMode != currentBrightnessMode) {
-        currentBrightnessMode = newMode;
-        uint8_t targetB =
-            (newMode == BrightnessMode::Day)  ? BACKLIGHT_DAY  :
-            (newMode == BrightnessMode::Dusk) ? BACKLIGHT_DUSK : BACKLIGHT_NIGHT;
-        display.setBrightness(targetB);
+    if (std::fabs(diff) <= 0.5f) {
+        smoothBrightness = targetBrightness;
+    } else {
+        smoothBrightness += step;
     }
+
+    display.setBrightness(static_cast<uint8_t>(smoothBrightness + 0.5f));
 }
 


### PR DESCRIPTION
## Summary / 概要
- add `BACKLIGHT_FILTER_ALPHA` and `BACKLIGHT_TRANSITION_SPEED` settings
- smooth brightness changes in `updateBacklightLevel()` using exponential moving average

## Testing
- `pio test` *(failed: network restrictions prevented downloading PlatformIO platform)*

------
https://chatgpt.com/codex/tasks/task_e_687daf88666c8322933da478a1a273bb