### PR TITLE
Add demo sensor mode / デモ用センサモード追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A compact digital dashboard driven by **M5Stack CoreS3 + ADS1015** that displays
 - 各種設定は `include/config.h` の定数で変更可能
 - 水温・油温は500ms間隔で取得し、2サンプル平均を1秒ごとに更新
 - 周囲光センサーによる自動調光（デフォルト無効）
+- デモモードでセンサー無しでも動作確認可能
 
 ### ハードウェア構成
 | モジュール       | 型番 / 仕様                       | 備考 |
@@ -135,6 +136,7 @@ Perfect for vintage cars lacking modern instrumentation or for lightweight track
 - Most settings are in `include/config.h`
 - Water and oil temperatures are sampled every 500 ms and averaged over 2 samples (updated every second)
 - Automatic backlight brightness using the ambient light sensor (disabled by default)
+- Demo mode lets you test without sensors connected
 
 ### Hardware Configuration
 | Module           | Part / Spec                    | Notes                   |

--- a/include/config.h
+++ b/include/config.h
@@ -4,8 +4,11 @@
 #include <M5CoreS3.h>
 
 // ────────────────────── 設定 ──────────────────────
-// デバッグモードを有効にするかどうか
+// デバッグ用メッセージ表示の有無
 constexpr bool DEBUG_MODE_ENABLED = true;
+
+// デモモードを有効にするかどうか
+constexpr bool DEMO_MODE_ENABLED  = false;
 
 // ── センサー接続可否（false にするとその項目は常に 0 表示） ──
 constexpr bool SENSOR_OIL_PRESSURE_PRESENT  = true;

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -101,7 +101,7 @@ void acquireSensorData()
 {
     static unsigned long previousWaterTempSampleTime = 0;
     static unsigned long previousOilTempSampleTime = 0;
-#if DEMO_MODE_ENABLED
+    // デモモード用の変数
     static bool demoActive        = true;   // デモ用センサ値生成フラグ
     static unsigned long dbgStart = 0;      // 初期化時刻
     static unsigned long dbgTick  = 0;      // インクリメントタイマ
@@ -109,12 +109,9 @@ void acquireSensorData()
     static float dbgOilPressure   = 0.0f;   // デバッグ油圧
     static float dbgWaterTemp     = 20.0f;  // デバッグ水温
     static float dbgOilTemp       = 20.0f;  // デバッグ油温
-#endif
     unsigned long now = millis();
 
-#if DEMO_MODE_ENABLED
-    // デモモード用のスタブ値生成
-    if (demoActive) {
+    if (DEMO_MODE_ENABLED && demoActive) {
         if (dbgStart == 0) {
             dbgStart = now;
             dbgTick  = now;
@@ -157,7 +154,6 @@ void acquireSensorData()
         oilPressureSampleIndex = (oilPressureSampleIndex + 1) % PRESSURE_SAMPLE_SIZE;
         return;
     }
-#endif
 
     // 油圧
     if (SENSOR_OIL_PRESSURE_PRESENT) {

--- a/src/modules/sensor.cpp
+++ b/src/modules/sensor.cpp
@@ -118,9 +118,9 @@ void acquireSensorData()
         }
 
         if (throttlePhase) {
-            // 最初の1秒はアクセルを吹かした時を想定し油圧を高くする
-            if (now - dbgStart < 1000) {
-                dbgOilPressure = 8.0f;
+            // 最初の2秒はアクセルを吹かした時を想定し油圧を高くする
+            if (now - dbgStart < 2000) {
+                dbgOilPressure = 8.1f;
             } else {
                 throttlePhase = false;
                 dbgOilPressure = 0.0f;


### PR DESCRIPTION
## Summary / 概要
- introduce `DEMO_MODE_ENABLED` constant
- simulate sensor behavior when demo mode is active
- update documentation for demo mode

## Testing
- `pio run -e m5stack-cores3` *(failed: could not download platform packages)*

------
https://chatgpt.com/codex/tasks/task_e_687dc38b469c8322b0f5209489efe652