### PR TITLE
テストのコメント化とセンサ関数復元 / Disable tests and revert sensor utilities

### DIFF
--- a/test/test_sensor_conversion.cpp
+++ b/test/test_sensor_conversion.cpp
@@ -1,0 +1,45 @@
+// 以下のテストは一時的に無効化しています
+// #include <unity.h>
+// #include "modules/sensor.h"
+
+// ────────────────────── convertVoltageToOilPressure のテスト ──────────────────────
+// void test_convertVoltageToOilPressure() {
+//     TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, convertVoltageToOilPressure(0.0f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, convertVoltageToOilPressure(0.5f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, convertVoltageToOilPressure(0.7f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.001f, 8.75f, convertVoltageToOilPressure(4.0f));
+// }
+
+// ────────────────────── convertVoltageToTemp のテスト ──────────────────────
+// void test_convertVoltageToTemp() {
+//     TEST_ASSERT_FLOAT_WITHIN(0.01f, 96.68f, convertVoltageToTemp(0.5f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.01f, 66.54f, convertVoltageToTemp(1.0f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.01f, 25.0f, convertVoltageToTemp(2.5f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.01f, 14.70f, convertVoltageToTemp(3.0f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.01f, -23.41f, convertVoltageToTemp(4.5f));
+//     TEST_ASSERT_FLOAT_WITHIN(0.01f, 200.0f, convertVoltageToTemp(0.0f));
+// }
+
+// ────────────────────── calculateAverage のテスト ──────────────────────
+// void test_calculateAverage() {
+//     float a1[] = {1.0f, 2.0f, 3.0f};
+//     TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f, calculateAverage(a1));
+
+//     float a2[] = {0.0f, 0.0f, 0.0f, 0.0f};
+//     TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, calculateAverage(a2));
+
+//     float a3[] = {2.0f, 4.0f, 6.0f, 8.0f};
+//     TEST_ASSERT_FLOAT_WITHIN(0.001f, 5.0f, calculateAverage(a3));
+// }
+
+// void setup() {
+//     UNITY_BEGIN();
+//     RUN_TEST(test_convertVoltageToOilPressure);
+//     RUN_TEST(test_convertVoltageToTemp);
+//     RUN_TEST(test_calculateAverage);
+//     UNITY_END();
+// }
+
+// void loop() {
+//     // テストループは空
+// }


### PR DESCRIPTION
## 概要 / Summary
- `test/test_sensor_conversion.cpp` にテスト内容をコメントアウトしたまま保持
- センサーモジュールのユーティリティ関数を元の `static` 状態へ戻し、ヘッダーから宣言を削除

## Testing
- `pio test -e m5stack-cores3-ci -f test_sensor_conversion.cpp -v` を実行するも、依存パッケージの取得に失敗

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687dd3749d488322911790393c16df2c