### PR TITLE
油圧メーター起動アニメーションの追加 / Add oil pressure startup animation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,9 @@ void setup()
     CoreS3.Ltr553.begin(&ltr553Params);
     CoreS3.Ltr553.setAlsMode(LTR5XX_ALS_ACTIVE_MODE);
   }
+
+  // 起動時に油圧メーターを煽るアニメーションを実行
+  runStartupPressureSweep();
 }
 
 // ────────────────────── loop() ──────────────────────

--- a/src/modules/display.h
+++ b/src/modules/display.h
@@ -2,6 +2,7 @@
 #define DISPLAY_H
 
 #include <M5GFX.h>
+
 #include "config.h"
 #include "sensor.h"
 
@@ -10,8 +11,9 @@ extern M5Canvas mainCanvas;
 extern int currentFps;
 
 void drawOilTemperatureTopBar(M5Canvas& canvas, float oilTemp, int maxOilTemp);
-void renderDisplayAndLog(float pressureAvg, float waterTempAvg,
-                       float oilTemp, int16_t maxOilTemp);
+void renderDisplayAndLog(float pressureAvg, float waterTempAvg, float oilTemp, int16_t maxOilTemp);
 void updateGauges();
+// 起動時の油圧メーターアニメーション
+void runStartupPressureSweep();
 
-#endif // DISPLAY_H
+#endif  // DISPLAY_H


### PR DESCRIPTION
## Summary / 概要
- 起動時に油圧メーターを0から8barまで往復させるアニメーションを追加
- `runStartupPressureSweep` を新設し `setup()` 終了時に呼び出す

## Testing / テスト
- `clang-format` と `clang-tidy` を実行
- `pio test` は依存パッケージの取得に失敗しテストを実行できず


------
https://chatgpt.com/codex/tasks/task_e_687dd962b868832280cbd2ad95d4d4f6