### PR TITLE
デバッグモードで電圧を表示 / Show voltage in debug mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,11 @@ static void printSensorDebugInfo()
   float pressure = calculateAverage(oilPressureSamples);
   float water = calculateAverage(waterTemperatureSamples);
   float oil = calculateAverage(oilTemperatureSamples);
-  Serial.printf("Oil.P: %.2f bar, Water.T: %.1f C, Oil.T: %.1f C\n", pressure, water, oil);
+  float pressureV = calculateAverage(oilPressureVoltageSamples);
+  float waterV = calculateAverage(waterTempVoltageSamples);
+  float oilV = calculateAverage(oilTempVoltageSamples);
+  Serial.printf("Oil.P: %.2f bar (%.2f V), Water.T: %.1f C (%.2f V), Oil.T: %.1f C (%.2f V)\n", pressure, pressureV, water,
+                waterV, oil, oilV);
 }
 
 // ────────────────────── setup() ──────────────────────

--- a/src/modules/sensor.h
+++ b/src/modules/sensor.h
@@ -3,13 +3,17 @@
 
 #include <Adafruit_ADS1X15.h>
 #include <stdint.h>
+
 #include "config.h"
 
 extern Adafruit_ADS1015 adsConverter;
 
 extern float oilPressureSamples[PRESSURE_SAMPLE_SIZE];
+extern float oilPressureVoltageSamples[PRESSURE_SAMPLE_SIZE];
 extern float waterTemperatureSamples[WATER_TEMP_SAMPLE_SIZE];
+extern float waterTempVoltageSamples[WATER_TEMP_SAMPLE_SIZE];
 extern float oilTemperatureSamples[OIL_TEMP_SAMPLE_SIZE];
+extern float oilTempVoltageSamples[OIL_TEMP_SAMPLE_SIZE];
 
 void acquireSensorData();
 
@@ -18,10 +22,11 @@ template <size_t N>
 inline float calculateAverage(const float (&values)[N])
 {
   float sum = 0.0f;
-  for (size_t i = 0; i < N; ++i) {
-      sum += values[i];
+  for (size_t i = 0; i < N; ++i)
+  {
+    sum += values[i];
   }
   return sum / static_cast<float>(N);
 }
 
-#endif // SENSOR_H
+#endif  // SENSOR_H


### PR DESCRIPTION
## 日本語
- デバッグ表示に各センサーの電圧を追加しました
- `sensor.cpp` と `sensor.h` に電圧用バッファを実装
- 取得処理を変更し、電圧値も保存します
- `printSensorDebugInfo` で電圧を含めて出力します
- テスト実行時、依存取得がネットワーク制限により失敗しました

## English
- Added voltage values to debug serial output
- Implemented voltage buffers in `sensor.cpp` and header
- Updated acquisition logic to store voltages
- `printSensorDebugInfo` now prints voltage along with pressure and temperatures
- PlatformIO tests could not run due to network restrictions

------
https://chatgpt.com/codex/tasks/task_e_687f07142a9c83229d1e47b65dc9033c